### PR TITLE
Lower ServerVersion restrictions

### DIFF
--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/ServerVersion.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/ServerVersion.java
@@ -44,8 +44,8 @@ public final class ServerVersion implements Comparable<ServerVersion> {
      * Parse a {@link ServerVersion} from {@link ByteBuf} encoded by ASCII.
      *
      * @param version buffer encoded by ASCII
-     * @return A server version that value is {@literal major.minor.patch}
-     * @throws IllegalArgumentException if any version part overflows to a negative integer.
+     * @return A server version that value decode from {@code version}.
+     * @throws IllegalArgumentException if {@code version} is null, or any version part overflows to a negative integer.
      */
     public static ServerVersion parse(ByteBuf version) {
         requireNonNull(version, "version must not be null");

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/ServerVersion.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/ServerVersion.java
@@ -40,6 +40,13 @@ public final class ServerVersion implements Comparable<ServerVersion> {
         this.patch = patch;
     }
 
+    /**
+     * Parse a {@link ServerVersion} from {@link ByteBuf} encoded by ASCII.
+     *
+     * @param version buffer encoded by ASCII
+     * @return A server version that value is {@literal major.minor.patch}
+     * @throws IllegalArgumentException if any version part overflows to a negative integer.
+     */
     public static ServerVersion parse(ByteBuf version) {
         requireNonNull(version, "version must not be null");
 
@@ -48,6 +55,15 @@ public final class ServerVersion implements Comparable<ServerVersion> {
         return create(major, minor, readIntBeforePoint(version));
     }
 
+    /**
+     * Create a {@link ServerVersion} that value is {@literal major.minor.patch}.
+     *
+     * @param major must not be a negative integer
+     * @param minor must not be a negative integer
+     * @param patch must not be a negative integer
+     * @return A server version that value is {@literal major.minor.patch}
+     * @throws IllegalArgumentException if any version part is negative integer.
+     */
     public static ServerVersion create(int major, int minor, int patch) {
         require(major >= 0, "major version must not be a negative integer");
         require(minor >= 0, "minor version must not be a negative integer");
@@ -125,33 +141,35 @@ public final class ServerVersion implements Comparable<ServerVersion> {
     }
 
     private static int readIntBeforePoint(ByteBuf version) {
-        int digits = version.bytesBefore((byte) '.');
-        boolean hasPoint = true;
+        int readerIndex = version.readerIndex();
         int result = 0;
+        int digits = version.bytesBefore((byte) '.');
+        int completeIndex;
 
-        if (digits < 0) { // no '.'
-            hasPoint = false;
-            digits = version.readableBytes(); // read until end of buffer
+        if (digits < 0) {
+            // Contains not '.', read until end of buffer.
+            completeIndex = version.writerIndex();
 
-            if (digits < 1) { // can not read any byte
+            if (completeIndex <= readerIndex) {
+                // Cannot read any byte.
                 return 0;
             }
+        } else {
+            // Read before '.', and ignore last '.'
+            completeIndex = readerIndex + digits + 1;
         }
 
-        for (int i = 0; i < digits; ++i) {
-            byte current = version.readByte();
+        for (int i = readerIndex; i < completeIndex; ++i) {
+            byte current = version.getByte(i);
 
             if (current < '0' || current > '9') { // C style condition, maybe should use `!Character.isDigit(current)`?
-                throw new NumberFormatException("unknown character '" + ((char) current) + "' for parse server version");
+                break;
             }
 
             result = result * 10 + (current - '0');
         }
 
-        if (hasPoint) {
-            version.skipBytes(1); // skip the '.'
-        }
-
+        version.readerIndex(completeIndex);
         return result;
     }
 }

--- a/src/test/java/io/github/mirromutth/r2dbc/mysql/ServerVersionTest.java
+++ b/src/test/java/io/github/mirromutth/r2dbc/mysql/ServerVersionTest.java
@@ -41,6 +41,7 @@ class ServerVersionTest {
         assertEquals(v0, ServerVersion.create(0, 0, 0));
 
         assertEquals(v5_7_12, parse("5.7.12.17"));
+        assertEquals(v5_7_12, parse("5.7.12-17"));
         assertEquals(v5_7_12, parse("5.7.12.RELEASE"));
         assertEquals(v5_7_12, parse("5.7.12.RC2"));
         assertEquals(v5_7_12, parse("5.7.12RC2"));
@@ -48,20 +49,26 @@ class ServerVersionTest {
         assertEquals(v5_7_12, parse("5.7.12-RC2"));
 
         assertEquals(v8, parse("8"));
+        assertEquals(v8, parse("8-2"));
         assertEquals(v8, parse("8v2"));
         assertEquals(v8, parse("8-v2"));
         assertEquals(v8, parse("8.0"));
+        assertEquals(v8, parse("8.0-2"));
         assertEquals(v8, parse("8.0v2"));
+        assertEquals(v8, parse("8.0.0-2"));
         assertEquals(v8, parse("8.0.0v2"));
         assertEquals(v8, parse("8.0.0-v2"));
 
         assertEquals(v8_1, parse("8.1"));
+        assertEquals(v8_1, parse("8.1-2"));
         assertEquals(v8_1, parse("8.1v2"));
         assertEquals(v8_1, parse("8.1-v2"));
+        assertEquals(v8_1, parse("8.1.0-2"));
         assertEquals(v8_1, parse("8.1.0v2"));
         assertEquals(v8_1, parse("8.1.0-v2"));
 
         assertEquals(v56_78_910, parse("56.78.910.17"));
+        assertEquals(v56_78_910, parse("56.78.910-12"));
         assertEquals(v56_78_910, parse("56.78.910.RELEASE"));
         assertEquals(v56_78_910, parse("56.78.910.RC2"));
         assertEquals(v56_78_910, parse("56.78.910RC2"));

--- a/src/test/java/io/github/mirromutth/r2dbc/mysql/ServerVersionTest.java
+++ b/src/test/java/io/github/mirromutth/r2dbc/mysql/ServerVersionTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.mirromutth.r2dbc.mysql;
+
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link ServerVersion}.
+ */
+class ServerVersionTest {
+
+    @Test
+    void parse() {
+        ServerVersion v5_7_12 = parse("5.7.12");
+        ServerVersion v8 = parse("8.0.0");
+        ServerVersion v8_1 = parse("8.1.0");
+        ServerVersion v56_78_910 = parse("56.78.910");
+        ServerVersion v0 = parse("");
+
+        assertEquals(v5_7_12, ServerVersion.create(5, 7, 12));
+        assertEquals(v8, ServerVersion.create(8, 0, 0));
+        assertEquals(v8_1, ServerVersion.create(8, 1, 0));
+        assertEquals(v56_78_910, ServerVersion.create(56, 78, 910));
+        assertEquals(v0, ServerVersion.create(0, 0, 0));
+
+        assertEquals(v5_7_12, parse("5.7.12.17"));
+        assertEquals(v5_7_12, parse("5.7.12.RELEASE"));
+        assertEquals(v5_7_12, parse("5.7.12.RC2"));
+        assertEquals(v5_7_12, parse("5.7.12RC2"));
+        assertEquals(v5_7_12, parse("5.7.12-v2"));
+        assertEquals(v5_7_12, parse("5.7.12-RC2"));
+
+        assertEquals(v8, parse("8"));
+        assertEquals(v8, parse("8v2"));
+        assertEquals(v8, parse("8-v2"));
+        assertEquals(v8, parse("8.0"));
+        assertEquals(v8, parse("8.0v2"));
+        assertEquals(v8, parse("8.0.0v2"));
+        assertEquals(v8, parse("8.0.0-v2"));
+
+        assertEquals(v8_1, parse("8.1"));
+        assertEquals(v8_1, parse("8.1v2"));
+        assertEquals(v8_1, parse("8.1-v2"));
+        assertEquals(v8_1, parse("8.1.0v2"));
+        assertEquals(v8_1, parse("8.1.0-v2"));
+
+        assertEquals(v56_78_910, parse("56.78.910.17"));
+        assertEquals(v56_78_910, parse("56.78.910.RELEASE"));
+        assertEquals(v56_78_910, parse("56.78.910.RC2"));
+        assertEquals(v56_78_910, parse("56.78.910RC2"));
+        assertEquals(v56_78_910, parse("56.78.910-v2"));
+        assertEquals(v56_78_910, parse("56.78.910-RC2"));
+    }
+
+    private static ServerVersion parse(String version) {
+        return ServerVersion.parse(Unpooled.wrappedBuffer(version.getBytes()));
+    }
+}


### PR DESCRIPTION
See #28 .

- Try ignore non-digit characters to support more version patterns.
- Add unit tests for `ServerVersion.parse`.
- Improve code comments for `ServerVersion.parse` and `ServerVersion.create`.

@pacphi The branch is `fix/version/parse` which contains those changes, target version is next milestone (`0.2.0.M2`). 