### PR TITLE
Refactor SSL configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,19 +28,19 @@
     <url>https://github.com/mirromutth/r2dbc-mysql</url>
 
     <properties>
-        <assertj.version>3.12.0</assertj.version>
+        <assertj.version>3.12.2</assertj.version>
         <java.version>1.8</java.version>
         <jsr305.version>3.0.2</jsr305.version>
-        <junit.version>5.4.2</junit.version>
+        <junit.version>5.5.1</junit.version>
         <logback.version>1.2.3</logback.version>
-        <mockito.version>2.27.0</mockito.version>
-        <mysql.version>8.0.16</mysql.version>
+        <mockito.version>3.0.0</mockito.version>
+        <mysql.version>8.0.17</mysql.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <r2dbc-spi.version>0.8.0.M8</r2dbc-spi.version>
         <reactor.version>Dysprosium-M1</reactor.version>
         <slf4j.version>1.7.26</slf4j.version>
-        <testcontainers.version>1.11.2</testcontainers.version>
+        <testcontainers.version>1.12.0</testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/MySqlConnectionFactory.java
@@ -17,6 +17,7 @@
 package io.github.mirromutth.r2dbc.mysql;
 
 import io.github.mirromutth.r2dbc.mysql.client.Client;
+import io.github.mirromutth.r2dbc.mysql.constant.SslMode;
 import io.github.mirromutth.r2dbc.mysql.internal.MySqlSession;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
@@ -56,11 +57,13 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             String host = configuration.getHost();
             int port = configuration.getPort();
             Duration connectTimeout = configuration.getConnectTimeout();
-            MySqlSslConfiguration sslConfiguration = configuration.getSslConfiguration();
-            Boolean requireSsl = sslConfiguration == null ? null : false;
+            MySqlSslConfiguration ssl = configuration.getSsl();
+            SslMode sslMode = ssl.getSslMode();
+            String username = configuration.getUsername();
+            CharSequence password = configuration.getPassword();
 
-            return Client.connect(ConnectionProvider.newConnection(), host, port, session, sslConfiguration, connectTimeout)
-                .flatMap(client -> LoginFlow.login(client, session, configuration.getUsername(), configuration.getPassword(), requireSsl))
+            return Client.connect(ConnectionProvider.newConnection(), host, port, ssl, session, connectTimeout)
+                .flatMap(client -> LoginFlow.login(client, sslMode, session, username, password))
                 .map(client -> new MySqlConnection(client, session));
         }));
     }

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -75,12 +75,8 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
         }
 
         Boolean isSsl = options.getValue(SSL);
-        if (isSsl != null) {
-            if (isSsl) {
-                builder.sslMode(SslMode.REQUIRED);
-            } else {
-                builder.sslMode(SslMode.DISABLED);
-            }
+        if (isSsl != null && !isSsl) {
+            builder.sslMode(SslMode.DISABLED);
         }
 
         String sslMode = options.getValue(SSL_MODE);

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -16,12 +16,14 @@
 
 package io.github.mirromutth.r2dbc.mysql;
 
+import io.github.mirromutth.r2dbc.mysql.constant.SslMode;
 import io.github.mirromutth.r2dbc.mysql.constant.ZeroDateOption;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
 import io.r2dbc.spi.Option;
 
+import static io.github.mirromutth.r2dbc.mysql.internal.AssertUtils.require;
 import static io.github.mirromutth.r2dbc.mysql.internal.AssertUtils.requireNonNull;
 import static io.r2dbc.spi.ConnectionFactoryOptions.CONNECT_TIMEOUT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
@@ -44,6 +46,18 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
      */
     public static final Option<String> ZERO_DATE = Option.valueOf("zeroDate");
 
+    public static final Option<String> SSL_MODE = Option.valueOf("sslMode");
+
+    public static final Option<String> TLS_VERSION = Option.valueOf("tlsVersion");
+
+    public static final Option<String> SSL_CA = Option.valueOf("sslCa");
+
+    public static final Option<String> SSL_KEY = Option.valueOf("sslKey");
+
+    public static final Option<CharSequence> SSL_KEY_PASSWORD = Option.sensitiveValueOf("sslKeyPassword");
+
+    public static final Option<String> SSL_CERT = Option.valueOf("sslCert");
+
     @Override
     public ConnectionFactory create(ConnectionFactoryOptions options) {
         requireNonNull(options, "connectionFactoryOptions must not be null");
@@ -61,8 +75,36 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
         }
 
         Boolean isSsl = options.getValue(SSL);
-        if (isSsl != null && isSsl) {
-            builder.enableSsl(ssl -> {});
+        if (isSsl != null) {
+            if (isSsl) {
+                builder.sslMode(SslMode.REQUIRED);
+            } else {
+                builder.sslMode(SslMode.DISABLED);
+            }
+        }
+
+        String sslMode = options.getValue(SSL_MODE);
+        if (sslMode != null) {
+            builder.sslMode(SslMode.valueOf(sslMode.toUpperCase()));
+        }
+
+        String tlsVersion = options.getValue(TLS_VERSION);
+        if (tlsVersion != null) {
+            builder.tlsVersion(tlsVersion.split(","));
+        }
+
+        String sslCa = options.getValue(SSL_CA);
+        if (sslCa != null) {
+            builder.sslCa(sslCa);
+        }
+
+        String sslCert = options.getValue(SSL_CERT);
+        String sslKey = options.getValue(SSL_KEY);
+        CharSequence sslKeyPassword = options.getValue(SSL_KEY_PASSWORD);
+        if (sslKey != null || sslCert != null) {
+            require(sslKey != null && sslCert != null, "SSL key and cert must be both null or both non-null");
+
+            builder.sslKeyAndCert(sslCert, sslKey, sslKeyPassword);
         }
 
         MySqlConnectionConfiguration configuration = builder.host(options.getRequiredValue(HOST))

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/client/Client.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/client/Client.java
@@ -54,10 +54,7 @@ public interface Client {
 
     void loginSuccess();
 
-    static Mono<Client> connect(
-        ConnectionProvider connectionProvider, String host, int port, MySqlSession session,
-        @Nullable MySqlSslConfiguration sslConfiguration, @Nullable Duration connectTimeout
-    ) {
+    static Mono<Client> connect(ConnectionProvider connectionProvider, String host, int port, MySqlSslConfiguration ssl, MySqlSession session, @Nullable Duration connectTimeout) {
         requireNonNull(connectionProvider, "connectionProvider must not be null");
         requireNonNull(host, "host must not be null");
 
@@ -70,6 +67,6 @@ public interface Client {
         return client.host(host)
             .port(port)
             .connect()
-            .map(conn -> new ReactorNettyClient(conn, session, sslConfiguration));
+            .map(conn -> new ReactorNettyClient(conn, ssl, session));
     }
 }

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/client/MySqlHostVerifier.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/client/MySqlHostVerifier.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.mirromutth.r2dbc.mysql.client;
+
+import io.github.mirromutth.r2dbc.mysql.internal.AddressUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.util.annotation.Nullable;
+
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static io.github.mirromutth.r2dbc.mysql.internal.AssertUtils.requireNonNull;
+
+/**
+ * MySQL hostname verifier, it is NOT an implementation of {@code HostnameVerifier}, because it
+ * needs to throw detailed exception which behavior not like {@code HostnameVerifier.verity}.
+ */
+final class MySqlHostVerifier {
+
+    private static final Logger logger = LoggerFactory.getLogger(MySqlHostVerifier.class);
+
+    private static final String COMMON_NAME = "CN";
+
+    private MySqlHostVerifier() {
+    }
+
+    static void accept(String host, SSLSession session) throws SSLException {
+        requireNonNull(host, "host must not be null");
+        requireNonNull(session, "session must not be null");
+
+        Certificate[] certs = session.getPeerCertificates();
+
+        if (certs.length < 1) {
+            throw new SSLException(String.format("Certificate for '%s' does not exists", host));
+        }
+
+        if (!(certs[0] instanceof X509Certificate)) {
+            throw new SSLException(String.format("Certificate for '%s' must be X509Certificate (not javax) rather than %s", host, certs[0].getClass()));
+        }
+
+        accepted(host, (X509Certificate) certs[0]);
+    }
+
+    private static void accepted(String host, X509Certificate cert) throws SSLException {
+        HostType type = determineHostType(host);
+        List<San> sans = extractSans(cert);
+
+        if (!sans.isEmpty()) {
+            // For self-signed certificate, supports SAN of IP.
+            switch (type) {
+                case IP_V4:
+                    matchIpv4(host, sans);
+                    break;
+                case IP_V6:
+                    matchIpv6(host, sans);
+                    break;
+                default:
+                    // Or just match DNS name?
+                    matchDns(host, sans);
+                    break;
+            }
+        } else {
+            // RFC 6125, validator must check SAN first, and if SAN exists, then CN should not be checked.
+            String cn = extractCn(cert);
+
+            if (cn == null) {
+                throw new SSLException(String.format("Certificate for '%s' does not contain the Common Name", host));
+            }
+
+            matchCn(host, cn);
+        }
+    }
+
+    private static void matchIpv4(String ip, List<San> sans) throws SSLPeerUnverifiedException {
+        for (San san : sans) {
+            // IP must be case sensitive.
+            if (San.IP == san.getType() && ip.equals(san.getValue())) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Certificate for '{}' matched by IPv4 value '{}' of the Subject Alternative Names", ip, san.getValue());
+                }
+                return;
+            }
+        }
+
+        throw new SSLPeerUnverifiedException(String.format("Certificate for '%s' does not match any of the Subject Alternative Names: %s", ip, sans));
+    }
+
+    private static void matchIpv6(String ip, List<San> sans) throws SSLPeerUnverifiedException {
+        String host = normaliseIpv6(ip);
+
+        for (San san : sans) {
+            // IP must be case sensitive.
+            if (san.getType() == San.IP && host.equals(normaliseIpv6(san.getValue()))) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Certificate for '{}' matched by IPv6 value '{}' of the Subject Alternative Names", ip, san.getValue());
+                }
+                return;
+            }
+        }
+
+        throw new SSLPeerUnverifiedException(String.format("Certificate for '%s' does not match any of the Subject Alternative Names: %s", ip, sans));
+    }
+
+    private static void matchDns(String hostname, List<San> sans) throws SSLPeerUnverifiedException {
+        String host = hostname.toLowerCase(Locale.ROOT);
+
+        if (host.isEmpty() || host.charAt(0) == '.' || host.endsWith("..")) {
+            // Invalid hostname
+            throw new SSLPeerUnverifiedException(String.format("Certificate for '%s' cannot match the Subject Alternative Names because it is invalid name", hostname));
+        }
+
+        for (San san : sans) {
+            if (san.getType() == San.DNS && matchHost(host, san.getValue().toLowerCase(Locale.ROOT))) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Certificate for '{}' matched by DNS name '{}' of the Subject Alternative Names", host, san.getValue());
+                }
+                return;
+            }
+        }
+
+        throw new SSLPeerUnverifiedException(String.format("Certificate for '%s' does not match any of the Subject Alternative Names: %s", hostname, sans));
+    }
+
+    private static void matchCn(String hostname, String commonName) throws SSLPeerUnverifiedException {
+        String host = hostname.toLowerCase(Locale.ROOT);
+        String cn = commonName.toLowerCase(Locale.ROOT);
+
+        if (host.isEmpty() || host.charAt(0) == '.' || host.endsWith("..") || !matchHost(host, cn)) {
+            throw new SSLPeerUnverifiedException(String.format("Certificate for '%s' does not match the Common Name: %s", hostname, commonName));
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Certificate for '{}' matched by Common Name '{}'", hostname, commonName);
+        }
+    }
+
+    /**
+     * @param host    must be a string of lower case and it must be validated hostname.
+     * @param pattern must be a string of lower case.
+     * @return {@code true} if {@code pattern} matching the {@code host}.
+     */
+    private static boolean matchHost(String host, String pattern) {
+        if (pattern.isEmpty() || pattern.charAt(0) == '.' || pattern.endsWith("..")) {
+            return false;
+        }
+
+        // RFC 2818, 3.1. Server Identity
+        // "...Names may contain the wildcard character * which is considered to match any single domain name component or component fragment..."
+        // According to this statement, assume that only a single wildcard is legal
+        int asteriskIndex = pattern.indexOf('*');
+
+        if (asteriskIndex < 0) {
+            // Both are lower case, so no need use equalsIgnoreCase.
+            return host.equals(pattern);
+        }
+
+        int patternSize = pattern.length();
+
+        if (patternSize == 1) {
+            // No one can signature certificate for "*".
+            return false;
+        }
+
+        if (asteriskIndex > 0) {
+            String prefix = pattern.substring(0, asteriskIndex);
+
+            if (!host.startsWith(prefix)) {
+                return false;
+            }
+        }
+
+        int postfixSize = patternSize - asteriskIndex - 1;
+
+        if (postfixSize > 0) {
+            String postfix = pattern.substring(asteriskIndex + 1);
+
+            if (!host.endsWith(postfix)) {
+                return false;
+            }
+        }
+
+        int remainderIndex = host.length() - postfixSize;
+
+        if (remainderIndex <= asteriskIndex) {
+            // Asterisk must to match least one character.
+            // In other words: groups.*.example.com can not match groups..example.com
+            return false;
+        }
+
+        String remainder = host.substring(asteriskIndex, remainderIndex);
+        // Asterisk cannot match across domain name labels.
+        return !remainder.contains(".");
+    }
+
+    @Nullable
+    private static String extractCn(X509Certificate cert) throws SSLException {
+        String principal = cert.getSubjectX500Principal().getName(X500Principal.RFC2253);
+        LdapName name;
+
+        try {
+            name = new LdapName(principal);
+        } catch (InvalidNameException e) {
+            throw new SSLException(e.getMessage(), e);
+        }
+
+        for (Rdn rdn : name.getRdns()) {
+            if (rdn.getType().equalsIgnoreCase(COMMON_NAME)) {
+                return rdn.getValue().toString();
+            }
+        }
+
+        return null;
+    }
+
+    private static List<San> extractSans(X509Certificate cert) {
+        try {
+            Collection<List<?>> pairs = cert.getSubjectAlternativeNames();
+
+            if (pairs == null || pairs.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            List<San> sans = new ArrayList<>();
+
+            for (List<?> pair : pairs) {
+                // Ignore if it is not a pair.
+                if (pair == null || pair.size() < 2) {
+                    continue;
+                }
+
+                Integer type = determineSubjectType(pair.get(0));
+
+                if (type == null) {
+                    continue;
+                }
+
+                if (San.DNS == type || San.IP == type) {
+                    Object value = pair.get(1);
+
+                    if (value instanceof String) {
+                        sans.add(new San((String) value, type));
+                    } else if (value instanceof byte[]) {
+                        // TODO: decode ASN.1 DER form.
+                        logger.warn("Certificate contains an ASN.1 DER encoded form in Subject Alternative Names, but DER is unsupported now");
+                    } else if (logger.isWarnEnabled()) {
+                        logger.warn("Certificate contains an unknown value of Subject Alternative Names: {}", value.getClass());
+                    }
+                } else {
+                    logger.warn("Certificate contains an unknown type of Subject Alternative Names: {}", type);
+                }
+            }
+
+            return sans;
+        } catch (CertificateParsingException ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    private static String normaliseIpv6(String ip) {
+        try {
+            return InetAddress.getByName(ip).getHostAddress();
+        } catch (UnknownHostException unexpected) {
+            return ip;
+        }
+    }
+
+    private static HostType determineHostType(String hostname) {
+        if (AddressUtils.isIpv4(hostname)) {
+            return HostType.IP_V4;
+        }
+
+        int maxIndex = hostname.length() - 1;
+        String host;
+
+        if (hostname.charAt(0) == '[' && hostname.charAt(maxIndex) == ']') {
+            host = hostname.substring(1, maxIndex);
+        } else {
+            host = hostname;
+        }
+
+        if (AddressUtils.isIpv6(host)) {
+            return HostType.IP_V6;
+        }
+
+        return HostType.DNS;
+    }
+
+    @Nullable
+    private static Integer determineSubjectType(Object type) {
+        if (type instanceof Integer) {
+            return (Integer) type;
+        } else {
+            try {
+                return Integer.parseInt(type.toString());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+    }
+
+    private enum HostType {
+
+        IP_V6,
+        IP_V4,
+        DNS
+    }
+}

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/client/San.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/client/San.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.mirromutth.r2dbc.mysql.client;
+
+import java.util.Objects;
+
+import static io.github.mirromutth.r2dbc.mysql.internal.AssertUtils.require;
+import static io.github.mirromutth.r2dbc.mysql.internal.AssertUtils.requireNonNull;
+
+/**
+ * Subject Alternative Name (aka. SAN, subjectAltName) in SSL.
+ * <p>
+ * RFC 5280, Section 4.1.2.6
+ * The subject name maybe carried in the subject field and/or the subjectAltName extension
+ */
+final class San {
+
+    static final int DNS = 2;
+
+    static final int IP = 7;
+
+    private final String value;
+
+    private final int type;
+
+    San(String value, int type) {
+        require(type > 0, "type must be a positive integer");
+
+        this.value = requireNonNull(value, "value must not be null");
+        this.type = type;
+    }
+
+    int getType() {
+        return type;
+    }
+
+    String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof San)) {
+            return false;
+        }
+        San that = (San) o;
+        return type == that.type && value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, type);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/collation/MixCharsetTarget.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/collation/MixCharsetTarget.java
@@ -101,7 +101,6 @@ final class MixCharsetTarget extends AbstractCharsetTarget {
         if (!Objects.equals(fallbackCharset, that.fallbackCharset)) {
             return false;
         }
-        // Probably incorrect - comparing Object[] arrays with Arrays.equals
         return Arrays.equals(targets, that.targets);
     }
 

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/constant/SslMode.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/constant/SslMode.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.mirromutth.r2dbc.mysql.constant;
+
+/**
+ * The mode of SSL considers the security of MySQL connections.
+ */
+public enum SslMode {
+
+    /**
+     * Establish an unencrypted connection.
+     * <p>
+     * In other words: I don't care about security and don't want to pay the overhead for encryption.
+     */
+    DISABLED,
+
+    /**
+     * Establish an encrypted connection if the server supports encrypted connections, otherwise fallback to an unencrypted connection.
+     * <p>
+     * In other words: I don't care about encryption but will pay the overhead of encryption if the server supports it.
+     */
+    PREFERRED,
+
+    /**
+     * Establish an encrypted connection if the server supports encrypted connections, otherwise the connection fails.
+     * <p>
+     * In other words: I want my data to be encrypted, and I accept the overhead. I trust that the network will make sure I always connect to the server I want.
+     */
+    REQUIRED,
+
+    /**
+     * Establish an encrypted connection based on {@link #REQUIRED} with verify the server Certificate Authority (CA) certificates.
+     * The connection attempt fails if CA certificates mismatched.
+     * <p>
+     * In other words: I want my data encrypted, and I accept the overhead. I want to be sure that I connect to a server that I trust.
+     */
+    VERIFY_CA,
+
+    /**
+     * Establish an encrypted connection based on {@link #VERIFY_CA}, additionally perform identity verification by checking the hostname.
+     * The connection attempt fails if the identity mismatched.
+     * <p>
+     * In other words: I want my data encrypted, and I accept the overhead. I want to be sure that I connect to a server I trust, and that it's the one I specify.
+     */
+    VERIFY_IDENTITY;
+
+    public final boolean requireSsl() {
+        return REQUIRED == this || VERIFY_CA == this || VERIFY_IDENTITY == this;
+    }
+
+    public final boolean startSsl() {
+        return DISABLED != this;
+    }
+
+    public final boolean verifyCertificate() {
+        return VERIFY_CA == this || VERIFY_IDENTITY == this;
+    }
+
+    public final boolean verifyIdentity() {
+        return VERIFY_IDENTITY == this;
+    }
+}

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/constant/TlsVersions.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/constant/TlsVersions.java
@@ -17,11 +17,11 @@
 package io.github.mirromutth.r2dbc.mysql.constant;
 
 /**
- * All TLS protocol names supported by MySQL.
+ * All TLS protocol version names supported by MySQL.
  */
-public final class TlsProtocols {
+public final class TlsVersions {
 
-    private TlsProtocols() {
+    private TlsVersions() {
     }
 
     public static final String TLS1 = "TLSv1";
@@ -35,4 +35,12 @@ public final class TlsProtocols {
      * Note: The Enterprise Edition version will looks like {@literal 5.7.26-enterprise}.
      */
     public static final String TLS1_2 = "TLSv1.2";
+
+    /**
+     * The {@literal TLSv1.3} is available as of MySQL 8.0.16 or higher,
+     * but requires compiling MySQL using OpenSSL 1.1.1 or higher.
+     * <p>
+     * It will not be used unless user has set it up.
+     */
+    public static final String TLS1_3 = "TLSv1.3";
 }

--- a/src/main/java/io/github/mirromutth/r2dbc/mysql/internal/AddressUtils.java
+++ b/src/main/java/io/github/mirromutth/r2dbc/mysql/internal/AddressUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.mirromutth.r2dbc.mysql.internal;
+
+import java.util.regex.Pattern;
+
+/**
+ * A utility for matching host/address.
+ */
+public final class AddressUtils {
+
+    private static final Pattern IPV4_PATTERN = Pattern.compile("^(([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){2}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");
+
+    private static final Pattern IPV6_PATTERN = Pattern.compile("^[0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){7}$");
+
+    private static final Pattern IPV6_COMPRESSED_PATTERN = Pattern.compile("^(([0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,5})?)::(([0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,5})?)$");
+
+    private static final int IPV6_COLONS = 7;
+
+    private AddressUtils() {
+    }
+
+    public static boolean isIpv4(String host) {
+        // TODO: Use faster matches instead of regex.
+        return IPV4_PATTERN.matcher(host).matches();
+    }
+
+    public static boolean isIpv6(String host) {
+        // TODO: Use faster matches instead of regex.
+        return IPV6_PATTERN.matcher(host).matches() || isIpv6Compressed(host);
+    }
+
+    private static boolean isIpv6Compressed(String host) {
+        int length = host.length();
+        int colons = 0;
+
+        for (int i = 0; i < length; ++i) {
+            if (host.charAt(i) == ':') {
+                ++colons;
+            }
+        }
+
+        // TODO: Use faster matches instead of regex.
+        return colons <= IPV6_COLONS && IPV6_COMPRESSED_PATTERN.matcher(host).matches();
+    }
+}

--- a/src/test/java/io/github/mirromutth/r2dbc/mysql/internal/AddressUtilsTest.java
+++ b/src/test/java/io/github/mirromutth/r2dbc/mysql/internal/AddressUtilsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.mirromutth.r2dbc.mysql.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AddressUtils}.
+ */
+class AddressUtilsTest {
+
+    @Test
+    void isIpv4() {
+        assertTrue(AddressUtils.isIpv4("127.0.0.1"));
+        assertTrue(AddressUtils.isIpv4("10.11.12.13"));
+        assertTrue(AddressUtils.isIpv4("192.168.0.0"));
+        assertTrue(AddressUtils.isIpv4("255.255.255.255"));
+
+        assertFalse(AddressUtils.isIpv4(" 127.0.0.1 "));
+        assertFalse(AddressUtils.isIpv4("01.11.12.13"));
+        assertFalse(AddressUtils.isIpv4("092.168.0.1"));
+        assertFalse(AddressUtils.isIpv4("055.255.255.255"));
+        assertFalse(AddressUtils.isIpv4("g.ar.ba.ge"));
+        assertFalse(AddressUtils.isIpv4("192.168.0"));
+        assertFalse(AddressUtils.isIpv4("192.168.0a.0"));
+        assertFalse(AddressUtils.isIpv4("256.255.255.255"));
+        assertFalse(AddressUtils.isIpv4("0.255.255.255"));
+
+        assertFalse(AddressUtils.isIpv4("::"));
+        assertFalse(AddressUtils.isIpv4("::1"));
+        assertFalse(AddressUtils.isIpv4("0:0:0:0:0:0:0:0"));
+        assertFalse(AddressUtils.isIpv4("0:0:0:0:0:0:0:1"));
+        assertFalse(AddressUtils.isIpv4("2001:0acd:0000:0000:0000:0000:3939:21fe"));
+        assertFalse(AddressUtils.isIpv4("2001:acd:0:0:0:0:3939:21fe"));
+        assertFalse(AddressUtils.isIpv4("2001:0acd:0:0::3939:21fe"));
+        assertFalse(AddressUtils.isIpv4("2001:0acd::3939:21fe"));
+        assertFalse(AddressUtils.isIpv4("2001:acd::3939:21fe"));
+    }
+
+    @Test
+    void isIpv6() {
+        assertTrue(AddressUtils.isIpv6("::"));
+        assertTrue(AddressUtils.isIpv6("::1"));
+        assertTrue(AddressUtils.isIpv6("0:0:0:0:0:0:0:0"));
+        assertTrue(AddressUtils.isIpv6("0:0:0:0:0:0:0:1"));
+        assertTrue(AddressUtils.isIpv6("2001:0acd:0000:0000:0000:0000:3939:21fe"));
+        assertTrue(AddressUtils.isIpv6("2001:acd:0:0:0:0:3939:21fe"));
+        assertTrue(AddressUtils.isIpv6("2001:0acd:0:0::3939:21fe"));
+        assertTrue(AddressUtils.isIpv6("2001:0acd::3939:21fe"));
+        assertTrue(AddressUtils.isIpv6("2001:acd::3939:21fe"));
+
+        assertFalse(AddressUtils.isIpv6(""));
+        assertFalse(AddressUtils.isIpv6(":1"));
+        assertFalse(AddressUtils.isIpv6("0:0:0:0:0:0:0"));
+        assertFalse(AddressUtils.isIpv6("0:0:0:0:0:0:0:0:0"));
+        assertFalse(AddressUtils.isIpv6("2001:0acd:0000:garb:age0:0000:3939:21fe"));
+        assertFalse(AddressUtils.isIpv6("2001:0agd:0000:0000:0000:0000:3939:21fe"));
+        assertFalse(AddressUtils.isIpv6("2001:0acd::0000::21fe"));
+        assertFalse(AddressUtils.isIpv6("1:2:3:4:5:6:7::9"));
+        assertFalse(AddressUtils.isIpv6("1::3:4:5:6:7:8:9"));
+        assertFalse(AddressUtils.isIpv6("::3:4:5:6:7:8:9"));
+        assertFalse(AddressUtils.isIpv6("1:2::4:5:6:7:8:9"));
+        assertFalse(AddressUtils.isIpv6("1:2:3:4:5:6::8:9"));
+
+        assertFalse(AddressUtils.isIpv6("127.0.0.1"));
+        assertFalse(AddressUtils.isIpv6("10.11.12.13"));
+        assertFalse(AddressUtils.isIpv6("192.168.0.0"));
+        assertFalse(AddressUtils.isIpv6("255.255.255.255"));
+    }
+}


### PR DESCRIPTION
See #33 .

- Simplified configuration code for easy to use.
- Support for checking the SSL capability for checking SSL mode.
- Add `SSLMode` to verify the CA and identity (hostname).