### PR TITLE
Relax options validation

### DIFF
--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -111,12 +111,7 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     @Override
     public boolean supports(ConnectionFactoryOptions options) {
         AssertUtils.requireNonNull(options, "connectionFactoryOptions must not be null");
-
-        if (!MYSQL_DRIVER.equals(options.getValue(DRIVER))) {
-            return false;
-        }
-
-        return options.hasOption(HOST) && options.hasOption(USER);
+        return MYSQL_DRIVER.equals(options.getValue(DRIVER));
     }
 
     @Override


### PR DESCRIPTION
See #56 .

`MySqlConnectionFactoryProvider.supports(…)` now only checks for the driver identifier and no longer for the presence of host/username options.

Requests to create a connection will fail with a more detailed exception about missing parameters.