### PR TITLE
Correct VARBINARY decoding

### DIFF
--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlColumnMetadata.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlColumnMetadata.java
@@ -161,7 +161,7 @@ final class MySqlColumnMetadata implements ColumnMetadata, FieldInformation {
             case DataTypes.VARCHAR:
             case DataTypes.JSON:
             case DataTypes.ENUMERABLE:
-            case DataTypes.VAR_STRING:
+            case DataTypes.VAR_BINARY:
             case DataTypes.STRING:
                 if (collationId == CharCollation.BINARY_ID) {
                     return byte[].class;

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlColumnMetadata.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlColumnMetadata.java
@@ -163,7 +163,11 @@ final class MySqlColumnMetadata implements ColumnMetadata, FieldInformation {
             case DataTypes.ENUMERABLE:
             case DataTypes.VAR_STRING:
             case DataTypes.STRING:
-                return String.class;
+                if (collationId == CharCollation.BINARY_ID) {
+                    return byte[].class;
+                } else {
+                    return String.class;
+                }
             case DataTypes.BIT:
             case DataTypes.GEOMETRY:
                 return byte[].class;

--- a/src/main/java/dev/miku/r2dbc/mysql/codec/DefaultCodecs.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/codec/DefaultCodecs.java
@@ -128,7 +128,7 @@ final class DefaultCodecs implements Codecs {
             }
         }
 
-        throw new IllegalArgumentException(String.format("Cannot decode value of type %s for type %d", target, info.getType()));
+        throw new IllegalArgumentException(String.format("Cannot decode value of type %s for type %d with collation %d", target, info.getType(), info.getCollationId()));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/dev/miku/r2dbc/mysql/codec/TypePredicates.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/codec/TypePredicates.java
@@ -46,7 +46,7 @@ final class TypePredicates {
     static boolean isString(short type) {
         return DataTypes.VARCHAR == type ||
             DataTypes.STRING == type ||
-            DataTypes.VAR_STRING == type ||
+            DataTypes.VAR_BINARY == type ||
             DataTypes.ENUMERABLE == type ||
             DataTypes.JSON == type ||
             DataTypes.SET == type;

--- a/src/main/java/dev/miku/r2dbc/mysql/constant/DataTypes.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/constant/DataTypes.java
@@ -92,7 +92,10 @@ public final class DataTypes {
      */
     public static final short BLOB = 252;
 
-    public static final short VAR_STRING = 253;
+    /**
+     * i.e. VAR STRING in MySQL documentation, but it is binary type.
+     */
+    public static final short VAR_BINARY = 253;
 
     public static final short STRING = 254;
 

--- a/src/test/java/dev/miku/r2dbc/mysql/PrepareQueryIntegrationTestSupport.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/PrepareQueryIntegrationTestSupport.java
@@ -76,10 +76,8 @@ abstract class PrepareQueryIntegrationTestSupport extends QueryIntegrationTestSu
             .verifyComplete();
     }
 
-    /**
-     * See https://github.com/mirromutth/r2dbc-mysql/issues/62 .
-     */
     @Test
+    @Override
     void varbinary() {
         testType(Object.class, "VARBINARY(50)", true, new byte[0], null, new byte[]{1,2,3,4,5});
     }

--- a/src/test/java/dev/miku/r2dbc/mysql/PrepareQueryIntegrationTestSupport.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/PrepareQueryIntegrationTestSupport.java
@@ -54,7 +54,7 @@ abstract class PrepareQueryIntegrationTestSupport extends QueryIntegrationTestSu
     }
 
     /**
-     * See https://github.com/mirromutth/r2dbc-mysql/issues/50.
+     * See https://github.com/mirromutth/r2dbc-mysql/issues/50 .
      */
     @Test
     void multiQueries() {
@@ -74,6 +74,14 @@ abstract class PrepareQueryIntegrationTestSupport extends QueryIntegrationTestSu
                 .then())
             .as(StepVerifier::create)
             .verifyComplete();
+    }
+
+    /**
+     * See https://github.com/mirromutth/r2dbc-mysql/issues/62 .
+     */
+    @Test
+    void varbinary() {
+        testType(Object.class, "VARBINARY(50)", true, new byte[0], null, new byte[]{1,2,3,4,5});
     }
 
     @Test

--- a/src/test/java/dev/miku/r2dbc/mysql/QueryIntegrationTestSupport.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/QueryIntegrationTestSupport.java
@@ -199,6 +199,12 @@ abstract class QueryIntegrationTestSupport extends IntegrationTestSupport {
         testType(EnumData.class, "ENUM('ONE','TWO','THREE')", true, null, EnumData.ONE, EnumData.TWO, EnumData.THREE);
     }
 
+    /**
+     * See https://github.com/mirromutth/r2dbc-mysql/issues/62 .
+     */
+    @Test
+    abstract void varbinary();
+
     @Test
     abstract void bit();
 

--- a/src/test/java/dev/miku/r2dbc/mysql/SimpleQueryIntegrationTestSupport.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/SimpleQueryIntegrationTestSupport.java
@@ -157,6 +157,12 @@ abstract class SimpleQueryIntegrationTestSupport extends QueryIntegrationTestSup
 
     @Test
     @Override
+    void varbinary() {
+        testTypeQuota(Object.class, "VARBINARY(50)", Functions.BYTE_ARRAY, false, new byte[0], null, new byte[]{1,2,3,4,5});
+    }
+
+    @Test
+    @Override
     void bit() {
         testTypeQuota(Boolean.class, "BIT(1)", Functions.BOOLEAN, false, null, false, true);
         testTypeQuota(byte[].class, "BIT(16)", Functions.BYTE_ARRAY, false, null, new byte[]{(byte) 0xCD, (byte) 0xEF});


### PR DESCRIPTION
See #62 .

Now the `Codecs` would be checking if the column metadata contains a valid charset.
Now containing `VARBINARY` integration test cases.
Now the exception that the decoding fails will include character collation ID.
Correct naming from `VAR_STRING` to `VAR_BINARY`.