### PR TITLE
Add ByteBuffer supports for Codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ If you want to raise an issue, please follow the recommendations below:
 - The MySQL database server does not **actively** return time zone when query `DATETIME` or `TIMESTAMP`, this driver does not attempt time zone conversion. That means should always use `LocalDateTime` for SQL type `DATETIME` or `TIMESTAMP`. Execute `SHOW VARIABLES LIKE '%time_zone%'` to get more information.
 - Do not turn-on the `trace` log level unless debugging. Otherwise, the security information may be exposed through `ByteBuf` dump.
 - If `Statement` bound `returnGeneratedValues`, the `Result` of the `Statement` can be called both: `getRowsUpdated` to get affected rows, and `map` to get last inserted ID.
-- Try not search some rows by binary field, like `BIT` or `BLOB`, MySQL supports such queries is not good.
+- Try not search some rows by binary field, like `BIT` or `BLOB`, MySQL supports such queries is not good (but `VARBINARY` is OK).
 
 ## License
 

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlColumnMetadata.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlColumnMetadata.java
@@ -29,6 +29,7 @@ import reactor.util.annotation.NonNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -161,15 +162,19 @@ final class MySqlColumnMetadata implements ColumnMetadata, FieldInformation {
             case DataTypes.VARCHAR:
             case DataTypes.JSON:
             case DataTypes.ENUMERABLE:
-            case DataTypes.VAR_BINARY:
+            case DataTypes.VARBINARY:
             case DataTypes.STRING:
                 if (collationId == CharCollation.BINARY_ID) {
-                    return byte[].class;
+                    return ByteBuffer.class;
                 } else {
                     return String.class;
                 }
             case DataTypes.BIT:
+                return ByteBuffer.class;
             case DataTypes.GEOMETRY:
+                // Most of Geometry libraries were using byte[] to encode/decode which based on WKT (includes Extended-WKT) or WKB
+                // MySQL using WKB for encoding/decoding, so use byte[] instead of ByteBuffer by default type.
+                // It maybe change after R2DBC SPI specify default type for GEOMETRY.
                 return byte[].class;
             case DataTypes.SET:
                 return String[].class;

--- a/src/main/java/dev/miku/r2dbc/mysql/codec/DefaultCodecs.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/codec/DefaultCodecs.java
@@ -62,6 +62,7 @@ final class DefaultCodecs implements Codecs {
         ClobCodec.INSTANCE,
         BlobCodec.INSTANCE,
 
+        ByteBufferCodec.INSTANCE,
         ByteArrayCodec.INSTANCE
     );
 

--- a/src/main/java/dev/miku/r2dbc/mysql/codec/TypePredicates.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/codec/TypePredicates.java
@@ -46,10 +46,14 @@ final class TypePredicates {
     static boolean isString(short type) {
         return DataTypes.VARCHAR == type ||
             DataTypes.STRING == type ||
-            DataTypes.VAR_BINARY == type ||
+            DataTypes.VARBINARY == type ||
             DataTypes.ENUMERABLE == type ||
             DataTypes.JSON == type ||
             DataTypes.SET == type;
+    }
+
+    static boolean isBinary(short type) {
+        return DataTypes.BIT == type || DataTypes.GEOMETRY == type || isString(type) || isLob(type);
     }
 
     private TypePredicates() {

--- a/src/main/java/dev/miku/r2dbc/mysql/constant/DataTypes.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/constant/DataTypes.java
@@ -95,7 +95,7 @@ public final class DataTypes {
     /**
      * i.e. VAR STRING in MySQL documentation, but it is binary type.
      */
-    public static final short VAR_BINARY = 253;
+    public static final short VARBINARY = 253;
 
     public static final short STRING = 254;
 

--- a/src/test/java/dev/miku/r2dbc/mysql/ConnectionIntegrationTestSupport.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/ConnectionIntegrationTestSupport.java
@@ -162,15 +162,13 @@ abstract class ConnectionIntegrationTestSupport extends IntegrationTestSupport {
     }
 
     private void complete(Function<? super MySqlConnection, Publisher<?>> runner) {
-        run(runner).then().as(StepVerifier::create).verifyComplete();
-    }
-
-    private Mono<Void> run(Function<? super MySqlConnection, Publisher<?>> runner) {
-        return connectionFactory.create()
+        connectionFactory.create()
             .flatMap(connection -> Flux.from(runner.apply(connection))
                 .onErrorResume(e -> close(connection).then(Mono.error(e)))
                 .concatWith(close(connection))
-                .then());
+                .then())
+            .as(StepVerifier::create)
+            .verifyComplete();
     }
 
     private static String formattedSelect(String condition) {


### PR DESCRIPTION
See #63 .

Binary-like types should use `ByteBuffer` by default type.
