### PR TITLE
Add change authentication phase handling

### DIFF
--- a/src/main/java/dev/miku/r2dbc/mysql/authentication/NoAuthProvider.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/authentication/NoAuthProvider.java
@@ -24,7 +24,7 @@ import static dev.miku.r2dbc.mysql.util.InternalArrays.EMPTY_BYTES;
 
 /**
  * A special authentication provider when server capabilities does not set {@code Capabilities.PLUGIN_AUTH}.
- * And {@code AuthChangeMessage} will be send by server after handshake response.
+ * And {@code ChangeAuthMessage} will be sent by server after handshake response.
  */
 final class NoAuthProvider implements MySqlAuthProvider {
 

--- a/src/main/java/dev/miku/r2dbc/mysql/message/client/AuthResponse.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/message/client/AuthResponse.java
@@ -24,13 +24,13 @@ import java.util.Arrays;
 import static dev.miku.r2dbc.mysql.util.AssertUtils.requireNonNull;
 
 /**
- * Full authentication response, i.e. authentication change response.
+ * A message that contains only an authentication, used by full authentication or change authentication response.
  */
-public final class FullAuthResponse extends EnvelopeClientMessage implements ExchangeableMessage {
+public final class AuthResponse extends EnvelopeClientMessage implements ExchangeableMessage {
 
     private final byte[] authentication;
 
-    public FullAuthResponse(byte[] authentication) {
+    public AuthResponse(byte[] authentication) {
         this.authentication = requireNonNull(authentication, "authentication must not be null");
     }
 
@@ -39,11 +39,11 @@ public final class FullAuthResponse extends EnvelopeClientMessage implements Exc
         if (this == o) {
             return true;
         }
-        if (!(o instanceof FullAuthResponse)) {
+        if (!(o instanceof AuthResponse)) {
             return false;
         }
 
-        FullAuthResponse that = (FullAuthResponse) o;
+        AuthResponse that = (AuthResponse) o;
 
         return Arrays.equals(authentication, that.authentication);
     }
@@ -55,7 +55,7 @@ public final class FullAuthResponse extends EnvelopeClientMessage implements Exc
 
     @Override
     public String toString() {
-        return "FullAuthResponse{authentication=REDACTED}";
+        return "AuthResponse{authentication=REDACTED}";
     }
 
     @Override

--- a/src/main/java/dev/miku/r2dbc/mysql/message/server/Eof320Message.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/message/server/Eof320Message.java
@@ -19,7 +19,7 @@ package dev.miku.r2dbc.mysql.message.server;
 /**
  * A EOF message for current context in protocol 3.20.
  * <p>
- * Note: It is also Old Authentication Change Request.
+ * Note: It is also Old Change Authentication Request.
  */
 final class Eof320Message implements EofMessage {
 

--- a/src/main/java/dev/miku/r2dbc/mysql/message/server/ServerMessageDecoder.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/message/server/ServerMessageDecoder.java
@@ -217,7 +217,7 @@ public final class ServerMessageDecoder {
                 if (EofMessage.isValidSize(buf.readableBytes())) {
                     return EofMessage.decode(buf);
                 } else {
-                    return AuthChangeMessage.decode(buf);
+                    return ChangeAuthMessage.decode(buf);
                 }
         }
 


### PR DESCRIPTION
See also #91 .

Corrected change authentication message decoding.

The "change authentication message" in MySQL 8.x can request client that change the authentication type from other to `caching_sha2_password`, and will send "authentication more data request" for this type.

So, this "change authentication phase" have to supports "authentication more data request" that not like "full authentication phase".
