### PR TITLE
Add customizer for SslContextBuilder

### DIFF
--- a/src/main/java/dev/miku/r2dbc/mysql/Binding.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/Binding.java
@@ -27,8 +27,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static dev.miku.r2dbc.mysql.util.AssertUtils.require;
-
 /**
  * A collection of {@link ParameterValue} for one bind invocation of a parametrized statement.
  *

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -18,10 +18,12 @@ package dev.miku.r2dbc.mysql;
 
 import dev.miku.r2dbc.mysql.constant.SslMode;
 import dev.miku.r2dbc.mysql.constant.ZeroDateOption;
+import io.netty.handler.ssl.SslContextBuilder;
 import reactor.util.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static dev.miku.r2dbc.mysql.util.InternalArrays.EMPTY_STRINGS;
@@ -210,6 +212,9 @@ public final class MySqlConnectionConfiguration {
         private String sslCert;
 
         @Nullable
+        private Function<SslContextBuilder, SslContextBuilder> sslContextBuilderCustomizer;
+
+        @Nullable
         private Predicate<String> preferPrepareStatement;
 
         private Builder() {
@@ -226,7 +231,7 @@ public final class MySqlConnectionConfiguration {
                 require(!sslMode.startSsl(), "sslMode must be disabled when using unix domain socket");
             }
 
-            MySqlSslConfiguration ssl = MySqlSslConfiguration.create(sslMode, tlsVersion, sslCa, sslKey, sslKeyPassword, sslCert);
+            MySqlSslConfiguration ssl = MySqlSslConfiguration.create(sslMode, tlsVersion, sslCa, sslKey, sslKeyPassword, sslCert, sslContextBuilderCustomizer);
             return new MySqlConnectionConfiguration(isHost, domain, port, ssl, connectTimeout, zeroDateOption, username, password, database, preferPrepareStatement);
         }
 
@@ -309,6 +314,13 @@ public final class MySqlConnectionConfiguration {
             this.sslCert = sslCert;
             this.sslKey = sslKey;
             this.sslKeyPassword = sslKeyPassword;
+            return this;
+        }
+
+        public Builder sslContextBuilderCustomizer(Function<SslContextBuilder, SslContextBuilder> customizer) {
+            requireNonNull(customizer, "sslContextBuilderCustomizer must not be null");
+
+            this.sslContextBuilderCustomizer = customizer;
             return this;
         }
 

--- a/src/main/java/dev/miku/r2dbc/mysql/SimpleStatementSupport.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/SimpleStatementSupport.java
@@ -19,9 +19,7 @@ package dev.miku.r2dbc.mysql;
 import dev.miku.r2dbc.mysql.client.Client;
 import dev.miku.r2dbc.mysql.codec.Codecs;
 import dev.miku.r2dbc.mysql.util.ConnectionContext;
-import reactor.core.publisher.Flux;
 
-import static dev.miku.r2dbc.mysql.util.AssertUtils.require;
 import static dev.miku.r2dbc.mysql.util.AssertUtils.requireNonNull;
 
 /**

--- a/src/main/java/dev/miku/r2dbc/mysql/client/SslBridgeHandler.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/client/SslBridgeHandler.java
@@ -179,7 +179,7 @@ final class SslBridgeHandler extends ChannelDuplexHandler {
             builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
         }
 
-        return builder;
+        return ssl.customizeSslContext(builder);
     }
 
     private static SslContextBuilder withTlsVersion(SslContextBuilder builder, MySqlSslConfiguration ssl, ServerVersion version) {

--- a/src/main/java/dev/miku/r2dbc/mysql/codec/DurationCodec.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/codec/DurationCodec.java
@@ -26,7 +26,6 @@ import io.netty.buffer.ByteBuf;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
-import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
 
 /**


### PR DESCRIPTION
See also #100 .

Allow customization of the used `SslContextBuilder` when lazily creating the `SslProvider`.