### PR TITLE
 execute methon in interface  MySqlStatement and implements class return type is not same

### DIFF
--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlStatement.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlStatement.java
@@ -18,6 +18,7 @@ package dev.miku.r2dbc.mysql;
 
 import io.r2dbc.spi.Statement;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
 
 /**
  * A strongly typed implementation of {@link Statement} for the MySQL database.
@@ -64,7 +65,7 @@ public interface MySqlStatement extends Statement {
      * {@inheritDoc}
      */
     @Override
-    Publisher<MySqlResult> execute();
+    Flux<MySqlResult> execute();
 
     /**
      * {@inheritDoc}

--- a/src/test/java/dev/miku/r2dbc/mysql/PrepareQueryIntegrationTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/PrepareQueryIntegrationTest.java
@@ -16,14 +16,10 @@
 
 package dev.miku.r2dbc.mysql;
 
-import com.mysql.cj.MysqlConnection;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Arrays;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -40,14 +36,12 @@ class PrepareQueryIntegrationTest extends QueryIntegrationTestSupport {
     void notSupportCompound() {
         String tdl = "CREATE TEMPORARY TABLE test(id INT PRIMARY KEY AUTO_INCREMENT,value INT)";
         badGrammar(connection -> Mono.from(connection.createStatement(tdl).execute())
-            .flatMap(IntegrationTestSupport::extractRowsUpdated)
-            .thenMany(connection.createStatement("INSERT INTO test(`value`) VALUES (?); INSERT INTO test(`value`) VALUES (?)")
-                .bind(0, 1)
-                .bind(1, 2)
-                .execute())
-            .flatMap(IntegrationTestSupport::extractRowsUpdated));
-
-        Function<? super MySqlConnection, Flux<MySqlResult>> runner= connection ->  (connection.createStatement(tdl).execute());
+                .flatMap(IntegrationTestSupport::extractRowsUpdated)
+                .thenMany(connection.createStatement("INSERT INTO test(`value`) VALUES (?); INSERT INTO test(`value`) VALUES (?)")
+                        .bind(0, 1)
+                        .bind(1, 2)
+                        .execute())
+                .flatMap(IntegrationTestSupport::extractRowsUpdated));
     }
 
     @Test

--- a/src/test/java/dev/miku/r2dbc/mysql/PrepareQueryIntegrationTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/PrepareQueryIntegrationTest.java
@@ -16,10 +16,14 @@
 
 package dev.miku.r2dbc.mysql;
 
+import com.mysql.cj.MysqlConnection;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Arrays;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -42,6 +46,8 @@ class PrepareQueryIntegrationTest extends QueryIntegrationTestSupport {
                 .bind(1, 2)
                 .execute())
             .flatMap(IntegrationTestSupport::extractRowsUpdated));
+
+        Function<? super MySqlConnection, Flux<MySqlResult>> runner= connection ->  (connection.createStatement(tdl).execute());
     }
 
     @Test


### PR DESCRIPTION
 
When i    using classTextParametrizedStatement
like 
Flux flux=TextParametrizedStatement().execute();
and the when i use MysqlStatement.execute metihod 
Publisher p=connection->connection.createStatement(select * from test ).execute();
 so mbaybe we can change that return type
