### PR TITLE
Add SSL tunnel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | sslCert | A path of local file which type is `PEM` | Required when `sslKey` exists | The SSL cert of client |
 | sslKey | A path of local file which type is `PEM` | Required when `sslCert` exists | The SSL key of client |
 | sslKeyPassword | Any valid password for `PEM` file | Optional, default `sslKey` has no password | The password for client SSL key (i.e. `sslKey`) |
+| tcpKeepAlive | Enable TCP KeepAlive | Optional, disabled. `true` or `false` | Controls TCP KeepAlive |
+| tcpNoDelay | Enable TCP NoDelay | Optional, disabled. `true` or `false` | Controls TCP NoDelay |
 | tlsVersion | Any value list of `TlsVersions` | Optional, default is auto-selected by the server | The TLS version for SSL, see following notice |
 | zeroDateOption | Any value of `ZeroDateOption` | Optional, default `USE_NULL` | The option indicates "zero date" handling, see following notice |
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
   - `REQUIRED` I want my data to be encrypted, and I accept the overhead. I trust that the network will make sure I always connect to the server I want. **Unavailable on Unix Domain Socket**
   - `VERIFY_CA` I want my data encrypted, and I accept the overhead. I want to be sure I connect to a server that I trust. **Unavailable on Unix Domain Socket**
   - `VERIFY_IDENTITY` (the highest level, most like web browser): I want my data encrypted, and I accept the overhead. I want to be sure I connect to a server I trust, and that it's the one I specify. **Unavailable on Unix Domain Socket**
+  - `TUNNEL`: Use a SSL tunnel to connect to MySQL. **Unavailable on Unix Domain Socket**
 - `TlsVersions` Considers TLS version names for SSL, can be **multi-values** in the configuration, make sure the database server supports selected TLS versions. **Unavailable on Unix Domain Socket**
   - `TLS1` (i.e. "TLSv1") Under generic circumstances, MySQL database supports it if database supports SSL
   - `TLS1_1` (i.e. "TLSv1.1") Under generic circumstances, MySQL database supports it if database supports SSL

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactory.java
@@ -77,7 +77,7 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             ConnectionContext context = new ConnectionContext(configuration.getZeroDateOption(), configuration.getServerZoneId());
             Extensions extensions = configuration.getExtensions();
 
-            return Client.connect(address, ssl, context, configuration.getConnectTimeout())
+            return Client.connect(ssl, address, configuration.isTcpKeepAlive(), configuration.isTcpNoDelay(), context, configuration.getConnectTimeout())
                 .flatMap(client -> LoginFlow.login(client, sslMode, database, context, user, password))
                 .flatMap(client -> {
                     ByteBufAllocator allocator = client.getByteBufAllocator();

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -62,6 +62,20 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
 
     public static final Option<Object> SSL_CONTEXT_BUILDER_CUSTOMIZER = Option.valueOf("sslContextBuilderCustomizer");
 
+    /**
+     * Enable TCP KeepAlive.
+     *
+     * @since 0.8.2
+     */
+    public static final Option<Object> TCP_KEEPALIVE = Option.valueOf("tcpKeepAlive");
+
+    /**
+     * Enable TCP NoDelay.
+     *
+     * @since 0.8.2
+     */
+    public static final Option<Object> TCP_NODELAY = Option.valueOf("tcpNoDelay");
+
     public static final Option<Object> USE_SERVER_PREPARE_STATEMENT = Option.valueOf("useServerPrepareStatement");
 
     public static final Option<Boolean> AUTODETECT_EXTENSIONS = Option.valueOf("autodetectExtensions");
@@ -134,9 +148,18 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             }
         }
 
-        String zeroDate = options.getValue(ZERO_DATE);
-        if (zeroDate != null) {
-            builder.zeroDateOption(ZeroDateOption.valueOf(zeroDate.toUpperCase()));
+        Object tcpKeepAlive = options.getValue(TCP_KEEPALIVE);
+        if (tcpKeepAlive != null) {
+            // Convert stringify option.
+            builder.tcpKeepAlive(tcpKeepAlive instanceof String ? Boolean
+                    .parseBoolean(tcpKeepAlive.toString()) : (Boolean) tcpKeepAlive);
+        }
+
+        Object tcpNoDelay = options.getValue(TCP_NODELAY);
+        if (tcpNoDelay != null) {
+            // Convert stringify option.
+            builder.tcpNoDelay(tcpNoDelay instanceof String ? Boolean
+                    .parseBoolean(tcpNoDelay.toString()) : (Boolean) tcpNoDelay);
         }
 
         Object serverPreparing = options.getValue(USE_SERVER_PREPARE_STATEMENT);

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlSslConfiguration.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlSslConfiguration.java
@@ -155,9 +155,11 @@ public final class MySqlSslConfiguration {
         }
 
         requireNonNull(tlsVersion, "tlsVersion must not be null");
-        require(!sslMode.verifyCertificate() || sslCa != null, "sslCa must not be null when verifying mode has set");
-        require((sslKey == null && sslCert == null) || (sslKey != null && sslCert != null), "sslKey and cert must be both null or both non-null");
 
         return new MySqlSslConfiguration(sslMode, tlsVersion, sslCa, sslKey, sslKeyPassword, sslCert, sslContextBuilderCustomizer);
+    }
+
+    public String getHostName() {
+        return null;
     }
 }

--- a/src/main/java/dev/miku/r2dbc/mysql/constant/SslMode.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/constant/SslMode.java
@@ -56,7 +56,15 @@ public enum SslMode {
      * <p>
      * In other words: I want my data encrypted, and I accept the overhead. I want to be sure that I connect to a server I trust, and that it's the one I specify.
      */
-    VERIFY_IDENTITY;
+    VERIFY_IDENTITY,
+
+    /**
+     * Establish an encrypted connection based on {@link #VERIFY_CA}, additionally perform identity verification by checking the hostname.
+     * The connection attempt fails if the identity mismatched.
+     * <p>
+     * In other words: I want to connect to a SSL proxy without using MySQL's SSL protocol.
+     */
+    TUNNEL;
 
     public final boolean requireSsl() {
         return REQUIRED == this || VERIFY_CA == this || VERIFY_IDENTITY == this;
@@ -67,7 +75,7 @@ public enum SslMode {
     }
 
     public final boolean verifyCertificate() {
-        return VERIFY_CA == this || VERIFY_IDENTITY == this;
+        return VERIFY_CA == this || VERIFY_IDENTITY == this || TUNNEL == this;
     }
 
     public final boolean verifyIdentity() {

--- a/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
@@ -159,6 +159,8 @@ class MySqlConnectionFactoryProviderTest {
             .option(Option.valueOf("sslKey"), "/path/to/client-key.pem")
             .option(Option.valueOf("sslCert"), "/path/to/client-cert.pem")
             .option(Option.valueOf("sslKeyPassword"), "ssl123456")
+            .option(Option.valueOf("tcpKeepAlive"), "true")
+            .option(Option.valueOf("tcpNoDelay"), "true")
             .build();
 
         assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);


### PR DESCRIPTION
This PR introduces support for SSL termination proxies (such as `stunnel` and Google Cloud MySQL). SSL is offloaded at the proxy. This form of SSL support does not follow the MySQL SSL protocol hence there's a slight change in the SSL flow.

Likely, follow-up code that negotiates SSL capabilities requires a change as capability negotiation should not consider SSL anymore. From a MySQL protocol perspective, the client should behave as if it would not support SSL, otherwise the driver could enter SSL-over-SSL which isn't a good idea.

The second commit adds support for TCP NoDelay and KeepAlive since both options seem required for GCP MySQL.

Related ticket: GoogleCloudPlatform/cloud-sql-jdbc-socket-factory#164