### PR TITLE
Add OptionMapper for factory provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ ConnectionFactory connectionFactory = ConnectionFactories.get(
     "zeroDate=use_round&" +
     "sslMode=verify_identity&" +
     "useServerPrepareStatement=true&" +
-    "tlsVersion=TLSv1.1%2CTLSv1.2%2CTLSv1.3&" +
+    "tlsVersion=TLSv1.3%2CTLSv1.2%2CTLSv1.1&" +
     "sslCa=%2Fpath%2Fto%2Fmysql%2Fca.pem&" +
     "sslKey=%2Fpath%2Fto%2Fmysql%2Fclient-key.pem&" +
     "sslCert=%2Fpath%2Fto%2Fmysql%2Fclient-cert.pem&" +
@@ -133,7 +133,7 @@ ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
     .option(Option.valueOf("sslKey"), "/path/to/mysql/client-key.pem") // optional, default null, null means has no client key
     .option(Option.valueOf("sslCert"), "/path/to/mysql/client-cert.pem") // optional, default null, null means has no client cert
     .option(Option.valueOf("sslKeyPassword"), "key-pem-password-in-here") // optional, default null, null means has no password for client key (i.e. "sslKey")
-    .option(Option.valueOf("tlsVersion"), "TLSv1.1,TLSv1.2,TLSv1.3") // optional, default is auto-selected by the server
+    .option(Option.valueOf("tlsVersion"), "TLSv1.3,TLSv1.2,TLSv1.1") // optional, default is auto-selected by the server
     .option(Option.valueOf("zeroDate"), "use_null") // optional, default "use_null"
     .option(Option.valueOf("useServerPrepareStatement"), true) // optional, default false
     .build();
@@ -169,8 +169,8 @@ MySqlConnectionConfiguration configuration = MySqlConnectionConfiguration.builde
     .connectTimeout(Duration.ofSeconds(3)) // optional, default null, null means no timeout
     .sslMode(SslMode.VERIFY_IDENTITY) // optional, default SslMode.PREFERRED
     .sslCa("/path/to/mysql/ca.pem") // required when sslMode is VERIFY_CA or VERIFY_IDENTITY, default null, null means has no server CA cert
-    .sslKeyAndCert("/path/to/mysql/client-cert.pem", "/path/to/mysql/client-key.pem", "key-pem-password-in-here") // optional, default has no client key and cert
-    .tlsVersion(TlsVersions.TLS1_1, TlsVersions.TLS1_2, TlsVersions.TLS1_3) // optional, default is auto-selected by the server
+    .sslCertAndKey("/path/to/mysql/client-cert.pem", "/path/to/mysql/client-key.pem", "key-pem-password-in-here") // optional, default has no client key and cert
+    .tlsVersion(TlsVersions.TLS1_3, TlsVersions.TLS1_2, TlsVersions.TLS1_1) // optional, default is auto-selected by the server
     .zeroDateOption(ZeroDateOption.USE_NULL) // optional, default ZeroDateOption.USE_NULL
     .useServerPrepareStatement() // Use server-preparing statements, default use client-preparing statements
     .build();
@@ -222,7 +222,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
   - `VERIFY_CA` I want my data encrypted, and I accept the overhead. I want to be sure I connect to a server that I trust. **Unavailable on Unix Domain Socket**
   - `VERIFY_IDENTITY` (the highest level, most like web browser): I want my data encrypted, and I accept the overhead. I want to be sure I connect to a server I trust, and that it's the one I specify. **Unavailable on Unix Domain Socket**
   - `TUNNEL`: Use a SSL tunnel to connect to MySQL. **Unavailable on Unix Domain Socket**
-- `TlsVersions` Considers TLS version names for SSL, can be **multi-values** in the configuration, make sure the database server supports selected TLS versions. **Unavailable on Unix Domain Socket**
+- `TlsVersions` Considers TLS version names for SSL, can be **multi-values** in the configuration, make sure the database server supports selected TLS versions. Usually sorted from higher to lower. **Unavailable on Unix Domain Socket**
   - `TLS1` (i.e. "TLSv1") Under generic circumstances, MySQL database supports it if database supports SSL
   - `TLS1_1` (i.e. "TLSv1.1") Under generic circumstances, MySQL database supports it if database supports SSL
   - `TLS1_2` (i.e. "TLSv1.2") Supported only in Community Edition `8.0.4` or higher, otherwise in Enterprise Edition `5.6.0` or higher

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -317,7 +317,8 @@ public final class MySqlConnectionConfiguration {
          * Configure the database.  Default no database.
          *
          * @param database the database, or {@code null} if no database want to be login.
-         * @return this {@link Builder}
+         * @return this {@link Builder}.
+         * @since 0.8.1
          */
         public Builder database(@Nullable String database) {
             this.database = database;
@@ -329,7 +330,8 @@ public final class MySqlConnectionConfiguration {
          *
          * @param unixSocket the socket file path.
          * @return this {@link Builder}.
-         * @throws IllegalArgumentException if {@code unixSocket} is {@code null}
+         * @throws IllegalArgumentException if {@code unixSocket} is {@code null}.
+         * @since 0.8.1
          */
         public Builder unixSocket(String unixSocket) {
             this.domain = requireNonNull(unixSocket, "unixSocket must not be null");
@@ -340,9 +342,10 @@ public final class MySqlConnectionConfiguration {
         /**
          * Configure the host.
          *
-         * @param host the host
-         * @return this {@link Builder}
-         * @throws IllegalArgumentException if {@code host} is {@code null}
+         * @param host the host.
+         * @return this {@link Builder}.
+         * @throws IllegalArgumentException if {@code host} is {@code null}.
+         * @since 0.8.1
          */
         public Builder host(String host) {
             this.domain = requireNonNull(host, "host must not be null");
@@ -356,7 +359,8 @@ public final class MySqlConnectionConfiguration {
          * Note: for memory security, should not use intern {@link String} for password.
          *
          * @param password the password, or {@code null} when user has no password.
-         * @return this {@link Builder}
+         * @return this {@link Builder}.
+         * @since 0.8.1
          */
         public Builder password(@Nullable CharSequence password) {
             this.password = password;
@@ -366,9 +370,10 @@ public final class MySqlConnectionConfiguration {
         /**
          * Configure the port.  Defaults to {@code 3306}.
          *
-         * @param port the port
-         * @return this {@link Builder}
+         * @param port the port.
+         * @return this {@link Builder}.
          * @throws IllegalArgumentException if the {@code port} is negative or bigger than {@literal 65535}.
+         * @since 0.8.1
          */
         public Builder port(int port) {
             require(port >= 0 && port <= 0xFFFF, "port must be between 0 and 65535");
@@ -381,7 +386,8 @@ public final class MySqlConnectionConfiguration {
          * Configure the connection timeout.  Default no timeout.
          *
          * @param connectTimeout the connection timeout, or {@code null} if has no timeout.
-         * @return this {@link Builder}
+         * @return this {@link Builder}.
+         * @since 0.8.1
          */
         public Builder connectTimeout(@Nullable Duration connectTimeout) {
             this.connectTimeout = connectTimeout;
@@ -392,8 +398,9 @@ public final class MySqlConnectionConfiguration {
          * Set the user for login the database.
          *
          * @param user the user.
-         * @return this {@link Builder}
-         * @throws IllegalArgumentException if {@code user} is {@code null}
+         * @return this {@link Builder}.
+         * @throws IllegalArgumentException if {@code user} is {@code null}.
+         * @since 0.8.2
          */
         public Builder user(String user) {
             this.user = requireNonNull(user, "user must not be null");
@@ -404,8 +411,9 @@ public final class MySqlConnectionConfiguration {
          * An alias of {@link #user(String)}.
          *
          * @param user the user.
-         * @return this {@link Builder}
-         * @throws IllegalArgumentException if {@code user} is {@code null}
+         * @return this {@link Builder}.
+         * @throws IllegalArgumentException if {@code user} is {@code null}.
+         * @since 0.8.1
          */
         public Builder username(String user) {
             return user(user);
@@ -415,7 +423,8 @@ public final class MySqlConnectionConfiguration {
          * Enforce the time zone of server.  Default to query server time zone in initialization (no enforce).
          *
          * @param serverZoneId the {@link ZoneId}, or {@code null} if query in initialization.
-         * @return this {@link Builder}
+         * @return this {@link Builder}.
+         * @since 0.8.2
          */
         public Builder serverZoneId(@Nullable ZoneId serverZoneId) {
             this.serverZoneId = serverZoneId;
@@ -427,8 +436,9 @@ public final class MySqlConnectionConfiguration {
          * See also {@link ZeroDateOption}.
          *
          * @param zeroDate the {@link ZeroDateOption}.
-         * @return this {@link Builder}
-         * @throws IllegalArgumentException if {@code zeroDate} is {@code null}
+         * @return this {@link Builder}.
+         * @throws IllegalArgumentException if {@code zeroDate} is {@code null}.
+         * @since 0.8.1
          */
         public Builder zeroDateOption(ZeroDateOption zeroDate) {
             this.zeroDateOption = requireNonNull(zeroDate, "zeroDateOption must not be null");
@@ -439,8 +449,9 @@ public final class MySqlConnectionConfiguration {
          * Configure ssl mode.  See also {@link SslMode}.
          *
          * @param sslMode the SSL mode to use.
-         * @return this {@link Builder}
-         * @throws IllegalArgumentException if {@code sslMode} is {@code null}
+         * @return this {@link Builder}.
+         * @throws IllegalArgumentException if {@code sslMode} is {@code null}.
+         * @since 0.8.1
          */
         public Builder sslMode(SslMode sslMode) {
             this.sslMode = requireNonNull(sslMode, "sslMode must not be null");
@@ -450,9 +461,10 @@ public final class MySqlConnectionConfiguration {
         /**
          * Configure TLS versions, see {@link dev.miku.r2dbc.mysql.constant.TlsVersions}.
          *
-         * @param tlsVersion TLS versions
-         * @return this {@link Builder}
+         * @param tlsVersion TLS versions.
+         * @return this {@link Builder}.
          * @throws IllegalArgumentException if the array {@code tlsVersion} is {@code null}.
+         * @since 0.8.1
          */
         public Builder tlsVersion(String... tlsVersion) {
             requireNonNull(tlsVersion, "tlsVersion must not be null");
@@ -493,8 +505,9 @@ public final class MySqlConnectionConfiguration {
          * Default is {@code null}, which means that the default algorithm is used for
          * the trust manager.
          *
-         * @param sslCa an X.509 certificate chain file in PEM format
-         * @return this {@link Builder}
+         * @param sslCa an X.509 certificate chain file in PEM format.
+         * @return this {@link Builder}.
+         * @since 0.8.1
          */
         public Builder sslCa(@Nullable String sslCa) {
             this.sslCa = sslCa;
@@ -507,14 +520,15 @@ public final class MySqlConnectionConfiguration {
          * The {@code sslCert} and {@code sslKey} must be both non-{@code null}
          * or both {@code null}.
          *
-         * @param sslCert an X.509 certificate chain file in PEM format
-         * @param sslKey  a PKCS#8 private key file in PEM format, should be not password-protected
-         * @return this {@link Builder}
+         * @param sslCert an X.509 certificate chain file in PEM format.
+         * @param sslKey  a PKCS#8 private key file in PEM format, should be not password-protected.
+         * @return this {@link Builder}.
          * @throws IllegalArgumentException if one of {@code sslCert} and {@code sslKey} is {@code null},
          *                                  and the other is non-{@code null}.
+         * @since 0.8.1
          */
-        public Builder sslKeyAndCert(@Nullable String sslCert, @Nullable String sslKey) {
-            return sslKeyAndCert(sslCert, sslKey, null);
+        public Builder sslCertAndKey(@Nullable String sslCert, @Nullable String sslKey) {
+            return sslCertAndKey(sslCert, sslKey, null);
         }
 
         /**
@@ -523,14 +537,15 @@ public final class MySqlConnectionConfiguration {
          * The {@code sslCert} and {@code sslKey} must be both non-{@code null}
          * or both {@code null}.
          *
-         * @param sslCert        an X.509 certificate chain file in PEM format
-         * @param sslKey         a PKCS#8 private key file in PEM format
-         * @param sslKeyPassword the password of the {@code sslKey}, or {@code null} if it's not password-protected
-         * @return this {@link Builder}
+         * @param sslCert        an X.509 certificate chain file in PEM format.
+         * @param sslKey         a PKCS#8 private key file in PEM format.
+         * @param sslKeyPassword the password of the {@code sslKey}, or {@code null} if it's not password-protected.
+         * @return this {@link Builder}.
          * @throws IllegalArgumentException if one of {@code sslCert} and {@code sslKey} is {@code null},
          *                                  and the other is non-{@code null}.
+         * @since 0.8.1
          */
-        public Builder sslKeyAndCert(@Nullable String sslCert, @Nullable String sslKey, @Nullable CharSequence sslKeyPassword) {
+        public Builder sslCertAndKey(@Nullable String sslCert, @Nullable String sslKey, @Nullable CharSequence sslKeyPassword) {
             require((sslCert == null && sslKey == null) || (sslCert != null && sslKey != null), "SSL key and cert must be both null or both non-null");
 
             this.sslCert = sslCert;
@@ -549,6 +564,7 @@ public final class MySqlConnectionConfiguration {
          * @param customizer customizer function
          * @return this {@link Builder}
          * @throws IllegalArgumentException if {@code customizer} is {@code null}
+         * @since 0.8.1
          */
         public Builder sslContextBuilderCustomizer(Function<SslContextBuilder, SslContextBuilder> customizer) {
             requireNonNull(customizer, "sslContextBuilderCustomizer must not be null");
@@ -563,7 +579,7 @@ public final class MySqlConnectionConfiguration {
          * @param enabled whether to enable TCP KeepAlive
          * @return this {@link Builder}
          * @see Socket#setKeepAlive(boolean)
-         * @since 0.8.1
+         * @since 0.8.2
          */
         public Builder tcpKeepAlive(boolean enabled) {
             this.tcpKeepAlive = enabled;
@@ -576,7 +592,7 @@ public final class MySqlConnectionConfiguration {
          * @param enabled whether to enable TCP NoDelay
          * @return this {@link Builder}
          * @see Socket#setTcpNoDelay(boolean)
-         * @since 0.8.1
+         * @since 0.8.2
          */
         public Builder tcpNoDelay(boolean enabled) {
             this.tcpNoDelay = enabled;
@@ -590,6 +606,7 @@ public final class MySqlConnectionConfiguration {
          * See also MySQL documentations.
          *
          * @return this {@link Builder}
+         * @since 0.8.1
          */
         public Builder useClientPrepareStatement() {
             this.preferPrepareStatement = null;
@@ -602,7 +619,8 @@ public final class MySqlConnectionConfiguration {
          * The binary protocol is compact protocol that's using server-preparing.
          * See also MySQL documentations.
          *
-         * @return this {@link Builder}
+         * @return this {@link Builder}.
+         * @since 0.8.1
          */
         public Builder useServerPrepareStatement() {
             return useServerPrepareStatement(DEFAULT_SERVER_PREPARE);
@@ -622,8 +640,9 @@ public final class MySqlConnectionConfiguration {
          * See also MySQL documentations.
          *
          * @param preferPrepareStatement the above {@link Predicate}.
-         * @return this {@link Builder}
-         * @throws IllegalArgumentException if {@code preferPrepareStatement} is {@code null}
+         * @return this {@link Builder}.
+         * @throws IllegalArgumentException if {@code preferPrepareStatement} is {@code null}.
+         * @since 0.8.1
          */
         public Builder useServerPrepareStatement(Predicate<String> preferPrepareStatement) {
             requireNonNull(preferPrepareStatement, "preferPrepareStatement must not be null");
@@ -636,8 +655,9 @@ public final class MySqlConnectionConfiguration {
          * Configures whether to use {@link ServiceLoader} to discover and register extensions.
          * Defaults to {@code true}.
          *
-         * @param enabled to discover and register extensions
-         * @return this {@link Builder}
+         * @param enabled to discover and register extensions.
+         * @return this {@link Builder}.
+         * @since 0.8.2
          */
         public Builder autodetectExtensions(boolean enabled) {
             this.autodetectExtensions = enabled;
@@ -652,9 +672,10 @@ public final class MySqlConnectionConfiguration {
          * this function and autodetect discovered, it will get two {@link Extension}
          * as same.
          *
-         * @param extension extension to extend driver functionality
-         * @return this {@link Builder}
+         * @param extension extension to extend driver functionality.
+         * @return this {@link Builder}.
          * @throws IllegalArgumentException if {@code extension} is {@code null}.
+         * @since 0.8.2
          */
         public Builder extendWith(Extension extension) {
             this.extensions.add(requireNonNull(extension, "extension must not be null"));

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlSslConfiguration.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlSslConfiguration.java
@@ -141,7 +141,7 @@ public final class MySqlSslConfiguration {
     @Override
     public String toString() {
         if (sslMode == SslMode.DISABLED) {
-            return "DISABLED";
+            return "MySqlSslConfiguration{sslMode=DISABLED}";
         }
 
         return String.format("MySqlSslConfiguration{sslMode=%s, tlsVersion=%s, sslHostnameVerifier=%s, sslCa='%s', sslKey='%s', sslKeyPassword=REDACTED, sslCert='%s', sslContextBuilderCustomizer=%s}",

--- a/src/main/java/dev/miku/r2dbc/mysql/OptionMapper.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/OptionMapper.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql;
+
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
+
+import java.util.Collection;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static dev.miku.r2dbc.mysql.MySqlConnectionFactoryProvider.SSL_CERT;
+import static dev.miku.r2dbc.mysql.MySqlConnectionFactoryProvider.SSL_KEY;
+
+/**
+ * An utility data parser for {@link Option}.
+ *
+ * @see MySqlConnectionFactoryProvider using this utility.
+ * @since 0.8.2
+ */
+final class OptionMapper {
+
+    private final ConnectionFactoryOptions options;
+
+    OptionMapper(ConnectionFactoryOptions options) {
+        this.options = options;
+    }
+
+    SourceSpec from(Option<?> option) {
+        return new SourceSpec(options, option);
+    }
+
+    BiSource sslCertAndKey() {
+        String leftValue = options.getValue(SSL_CERT);
+        String rightValue = options.getValue(SSL_KEY);
+
+        if (leftValue == null && rightValue == null) {
+            return Source.Nil.INSTANCE;
+        } else if (leftValue == null || rightValue == null) {
+            throw new IllegalArgumentException("SSL cert and key must be both null or both non-null");
+        }
+
+        return new BiSource.Impl(leftValue, rightValue);
+    }
+}
+
+final class SourceSpec {
+
+    private final ConnectionFactoryOptions options;
+
+    private final Option<?> option;
+
+    SourceSpec(ConnectionFactoryOptions options, Option<?> option) {
+        this.options = options;
+        this.option = option;
+    }
+
+    <T> Source<T> asInstance(Class<T> type) {
+        Object value = options.getValue(option);
+
+        if (value == null) {
+            return Source.nilSource();
+        }
+
+        if (type.isInstance(value)) {
+            return new Source.Impl<>(type.cast(value));
+        } else if (value instanceof String) {
+            try {
+                Class<?> implementation = Class.forName((String) value);
+
+                if (type.isAssignableFrom(implementation)) {
+                    return new Source.Impl<>(type.cast(implementation.getDeclaredConstructor().newInstance()));
+                }
+                // Otherwise not an implementation, convert failed.
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalArgumentException("Cannot instantiate '" + value + "'", e);
+            }
+        }
+
+        throw new IllegalArgumentException(toMessage(option, value, type.getName()));
+    }
+
+    <T> Source<T> asInstance(Class<T> type, Function<String, T> mapping) {
+        Object value = options.getValue(option);
+
+        if (value == null) {
+            return Source.nilSource();
+        }
+
+        if (type.isInstance(value)) {
+            return new Source.Impl<>(type.cast(value));
+        } else if (value instanceof String) {
+            // Type cast for check mapping result.
+            return new Source.Impl<>(type.cast(mapping.apply((String) value)));
+        }
+
+        throw new IllegalArgumentException(toMessage(option, value, type.getTypeName()));
+    }
+
+    Source<String[]> asStrings() {
+        Object value = options.getValue(option);
+
+        if (value == null) {
+            return Source.nilSource();
+        }
+
+        if (value instanceof String[]) {
+            return new Source.Impl<>((String[]) value);
+        } else if (value instanceof String) {
+            return new Source.Impl<>(((String) value).split(","));
+        } else if (value instanceof Collection<?>) {
+            return new Source.Impl<>(((Collection<?>) value).stream()
+                .map(String.class::cast).toArray(String[]::new));
+        }
+
+        throw new IllegalArgumentException(toMessage(option, value, "String[]"));
+    }
+
+    Source<Boolean> asBoolean() {
+        Object value = options.getValue(option);
+
+        if (value == null) {
+            return Source.nilSource();
+        }
+
+        if (value instanceof Boolean) {
+            return new Source.Impl<>((Boolean) value);
+        } else if (value instanceof String) {
+            return new Source.Impl<>(Boolean.parseBoolean((String) value));
+        }
+
+        throw new IllegalArgumentException(toMessage(option, value, "Boolean"));
+    }
+
+    Source<Integer> asInt() {
+        Object value = options.getValue(option);
+
+        if (value == null) {
+            return Source.nilSource();
+        }
+
+        if (value instanceof Integer) {
+            // Reduce the cost of re-boxed.
+            return new Source.Impl<>((Integer) value);
+        } else if (value instanceof Number) {
+            return new Source.Impl<>(((Number) value).intValue());
+        } else if (value instanceof String) {
+            return new Source.Impl<>(Integer.parseInt((String) value));
+        }
+
+        throw new IllegalArgumentException(toMessage(option, value, "Integer"));
+    }
+
+    Source<String> asString() {
+        Object value = options.getValue(option);
+
+        if (value == null) {
+            return Source.nilSource();
+        }
+
+        if (value instanceof String) {
+            return new Source.Impl<>((String) value);
+        }
+
+        throw new IllegalArgumentException(toMessage(option, value, "String"));
+    }
+
+    @SuppressWarnings("unchecked")
+    void servePrepare(Consumer<Boolean> enables, Consumer<Predicate<String>> preferred) {
+        Object value = options.getValue(option);
+
+        if (value == null) {
+            return;
+        }
+
+        if (value instanceof Boolean) {
+            enables.accept((Boolean) value);
+            return;
+        } else if (value instanceof Predicate<?>) {
+            preferred.accept((Predicate<String>) value);
+            return;
+        } else if (value instanceof String) {
+            String serverPreparing = (String) value;
+
+            if ("true".equalsIgnoreCase(serverPreparing) || "false".equalsIgnoreCase(serverPreparing)) {
+                enables.accept(Boolean.parseBoolean(serverPreparing));
+                return;
+            } else {
+                try {
+                    Class<?> implementation = Class.forName(serverPreparing);
+
+                    if (Predicate.class.isAssignableFrom(implementation)) {
+                        preferred.accept((Predicate<String>) implementation.getDeclaredConstructor().newInstance());
+                        return;
+                    }
+                    // Otherwise not an implementation, convert failed.
+                } catch (ReflectiveOperationException e) {
+                    throw new IllegalArgumentException("Cannot instantiate '" + value + "'", e);
+                }
+            }
+        }
+
+        throw new IllegalArgumentException(toMessage(option, value, "Boolean or Predicate<String>"));
+    }
+
+    private static String toMessage(Option<?> option, Object value, String type) {
+        return "Cannot convert value " + value + " of " + value.getClass() + " as " + type + " for option " + option.name();
+    }
+}
+
+@FunctionalInterface
+interface BiSource {
+
+    Otherwise into(BiConsumer<String, String> consumer);
+
+    final class Impl implements BiSource {
+
+        private final String left;
+
+        private final String right;
+
+        Impl(String left, String right) {
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public Otherwise into(BiConsumer<String, String> consumer) {
+            consumer.accept(left, right);
+            return Otherwise.NOOP;
+        }
+    }
+}
+
+@FunctionalInterface
+interface Source<T> {
+
+    Otherwise into(Consumer<T> consumer);
+
+    @SuppressWarnings("unchecked")
+    static <T> Source<T> nilSource() {
+        return (Source<T>) Nil.INSTANCE;
+    }
+
+    final class Impl<T> implements Source<T> {
+
+        private final T value;
+
+        Impl(T value) {
+            this.value = value;
+        }
+
+        public Otherwise into(Consumer<T> consumer) {
+            consumer.accept(value);
+            return Otherwise.NOOP;
+        }
+    }
+
+    enum Nil implements Source<Object>, BiSource {
+
+        INSTANCE;
+
+        @Override
+        public Otherwise into(Consumer<Object> consumer) {
+            return Otherwise.FALL;
+        }
+
+        @Override
+        public Otherwise into(BiConsumer<String, String> consumer) {
+            return Otherwise.FALL;
+        }
+    }
+}
+
+@FunctionalInterface
+interface Otherwise {
+
+    Otherwise NOOP = ignored -> {
+    };
+
+    Otherwise FALL = Runnable::run;
+
+    /**
+     * Invoked if the previous {@link Source} or {@link BiSource} outcome did not match.
+     *
+     * @param runnable the {@link Runnable} that should be invoked.
+     */
+    void otherwise(Runnable runnable);
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/client/SslBridgeHandler.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/client/SslBridgeHandler.java
@@ -16,11 +16,11 @@
 
 package dev.miku.r2dbc.mysql.client;
 
+import dev.miku.r2dbc.mysql.ConnectionContext;
 import dev.miku.r2dbc.mysql.MySqlSslConfiguration;
 import dev.miku.r2dbc.mysql.ServerVersion;
 import dev.miku.r2dbc.mysql.constant.SslMode;
 import dev.miku.r2dbc.mysql.constant.TlsVersions;
-import dev.miku.r2dbc.mysql.ConnectionContext;
 import dev.miku.r2dbc.mysql.message.server.SyntheticSslResponseMessage;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -196,9 +196,9 @@ final class SslBridgeHandler extends ChannelDuplexHandler {
         if (tlsProtocols.length > 0) {
             builder.protocols(tlsProtocols);
         } else if (isEnabledTls1_2(version)) {
-            builder.protocols(TlsVersions.TLS1, TlsVersions.TLS1_1, TlsVersions.TLS1_2);
+            builder.protocols(TlsVersions.TLS1_2, TlsVersions.TLS1_1, TlsVersions.TLS1);
         } else {
-            builder.protocols(TlsVersions.TLS1, TlsVersions.TLS1_1);
+            builder.protocols(TlsVersions.TLS1_1, TlsVersions.TLS1);
         }
 
         return builder;

--- a/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -191,7 +191,7 @@ class MySqlConnectionConfigurationTest {
             .connectTimeout(Duration.ofSeconds(3))
             .sslMode(SslMode.VERIFY_IDENTITY)
             .sslCa(SSL_CA)
-            .sslKeyAndCert("/path/to/mysql/client-cert.pem", "/path/to/mysql/client-key.pem", "pem-password-in-here")
+            .sslCertAndKey("/path/to/mysql/client-cert.pem", "/path/to/mysql/client-key.pem", "pem-password-in-here")
             .tlsVersion(TlsVersions.TLS1_1, TlsVersions.TLS1_2, TlsVersions.TLS1_3)
             .serverZoneId(ZoneId.systemDefault())
             .zeroDateOption(ZeroDateOption.USE_NULL)

--- a/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
@@ -17,14 +17,22 @@
 package dev.miku.r2dbc.mysql;
 
 import dev.miku.r2dbc.mysql.constant.SslMode;
+import dev.miku.r2dbc.mysql.constant.ZeroDateOption;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
+import org.assertj.core.api.Assert;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.time.Duration;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static dev.miku.r2dbc.mysql.MySqlConnectionFactoryProvider.USE_SERVER_PREPARE_STATEMENT;
@@ -37,7 +45,9 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * Unit test for {@link MySqlConnectionFactoryProvider}.
@@ -60,7 +70,7 @@ class MySqlConnectionFactoryProviderTest {
                 "zeroDate=use_round&" +
                 "sslMode=verify_identity&" +
                 "serverPreparing=true" +
-                String.format("tlsVersion=%s&", URLEncoder.encode("TLSv1.1,TLSv1.2,TLSv1.3", "UTF-8")) +
+                String.format("tlsVersion=%s&", URLEncoder.encode("TLSv1.3,TLSv1.2,TLSv1.1", "UTF-8")) +
                 String.format("sslCa=%s&", URLEncoder.encode("/path/to/ca.pem", "UTF-8")) +
                 String.format("sslKey=%s&", URLEncoder.encode("/path/to/client-key.pem", "UTF-8")) +
                 String.format("sslCert=%s&", URLEncoder.encode("/path/to/client-cert.pem", "UTF-8")) +
@@ -69,27 +79,27 @@ class MySqlConnectionFactoryProviderTest {
     }
 
     @Test
-    void invalidUrl() {
-        assertThat(assertThrows(
-            IllegalArgumentException.class,
-            () -> ConnectionFactories.get("r2dbcs:mysql://root@localhost:3306?" +
-                "unixSocket=" + URLEncoder.encode("/path/to/mysql.sock", "UTF-8"))).getMessage())
-            .contains("sslMode");
+    void urlSslModeInUnixSocket() throws UnsupportedEncodingException {
+        Assert<?, SslMode> that = assertThat(SslMode.DISABLED);
+
+        MySqlConnectionConfiguration configuration = MySqlConnectionFactoryProvider.setup(
+            ConnectionFactoryOptions.parse("r2dbcs:mysql://root@localhost:3306?" +
+                "unixSocket=" + URLEncoder.encode("/path/to/mysql.sock", "UTF-8")));
+
+        that.isEqualTo(configuration.getSsl().getSslMode());
 
         for (SslMode mode : SslMode.values()) {
-            if (mode.startSsl()) {
-                assertThat(assertThrows(
-                    IllegalArgumentException.class,
-                    () -> ConnectionFactories.get("r2dbc:mysql://root@localhost:3306?" +
-                        "unixSocket=" + URLEncoder.encode("/path/to/mysql.sock", "UTF-8") +
-                        "&sslMode=" + mode.name().toLowerCase())).getMessage())
-                    .contains("sslMode");
-            }
+            configuration = MySqlConnectionFactoryProvider.setup(
+                ConnectionFactoryOptions.parse("r2dbc:mysql://root@localhost:3306?" +
+                    "unixSocket=" + URLEncoder.encode("/path/to/mysql.sock", "UTF-8") +
+                    "&sslMode=" + mode.name().toLowerCase()));
+
+            that.isEqualTo(configuration.getSsl().getSslMode());
         }
     }
 
     @Test
-    void validProgrammatic() {
+    void validProgrammaticHost() {
         ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
             .option(DRIVER, "mysql")
             .option(HOST, "127.0.0.1")
@@ -109,43 +119,62 @@ class MySqlConnectionFactoryProviderTest {
 
         options = ConnectionFactoryOptions.builder()
             .option(DRIVER, "mysql")
-            .option(Option.valueOf("unixSocket"), "/path/to/mysql.sock")
-            .option(USER, "root")
-            .build();
-
-        assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);
-
-        options = ConnectionFactoryOptions.builder()
-            .option(DRIVER, "mysql")
-            .option(Option.valueOf("unixSocket"), "/path/to/mysql.sock")
-            .option(USER, "root")
-            .option(Option.valueOf("sslMode"), "disabled")
-            .build();
-
-        assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);
-
-        options = ConnectionFactoryOptions.builder()
-            .option(DRIVER, "mysql")
-            .option(Option.valueOf("unixSocket"), "/path/to/mysql.sock")
-            .option(USER, "root")
-            .option(SSL, false)
-            .build();
-
-        assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);
-
-        options = ConnectionFactoryOptions.builder()
-            .option(DRIVER, "mysql")
-            .option(Option.valueOf("unixSocket"), "/path/to/mysql.sock")
-            .option(USER, "root")
-            .option(Option.valueOf("sslMode"), "disabled")
-            .option(SSL, true)
-            .build();
-
-        assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);
-
-        options = ConnectionFactoryOptions.builder()
-            .option(DRIVER, "mysql")
             .option(HOST, "127.0.0.1")
+            .option(PORT, 3307)
+            .option(USER, "root")
+            .option(PASSWORD, "123456")
+            .option(SSL, true)
+            .option(Option.valueOf(CONNECT_TIMEOUT.name()), Duration.ofSeconds(3).toString())
+            .option(DATABASE, "r2dbc")
+            .option(Option.valueOf("serverZoneId"), "Asia/Tokyo")
+            .option(Option.valueOf("useServerPrepareStatement"), AllTruePredicate.class.getName())
+            .option(Option.valueOf("zeroDate"), "use_round")
+            .option(Option.valueOf("sslMode"), "verify_identity")
+            .option(Option.valueOf("tlsVersion"), "TLSv1.3,TLSv1.2")
+            .option(Option.valueOf("sslCa"), "/path/to/ca.pem")
+            .option(Option.valueOf("sslKey"), "/path/to/client-key.pem")
+            .option(Option.valueOf("sslCert"), "/path/to/client-cert.pem")
+            .option(Option.valueOf("sslKeyPassword"), "ssl123456")
+            .option(Option.valueOf("sslHostnameVerifier"), MyHostnameVerifier.class.getName())
+            .option(Option.valueOf("sslContextBuilderCustomizer"), SslCustomizer.class.getName())
+            .option(Option.valueOf("tcpKeepAlive"), "true")
+            .option(Option.valueOf("tcpNoDelay"), "true")
+            .build();
+
+        assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);
+
+        MySqlConnectionConfiguration configuration = MySqlConnectionFactoryProvider.setup(options);
+
+        assertThat(configuration.getDomain()).isEqualTo("127.0.0.1");
+        assertThat(configuration.isHost()).isTrue();
+        assertThat(configuration.getPort()).isEqualTo(3307);
+        assertThat(configuration.getUser()).isEqualTo("root");
+        assertThat(configuration.getPassword()).isEqualTo("123456");
+        assertThat(configuration.getConnectTimeout()).isEqualTo(Duration.ofSeconds(3));
+        assertThat(configuration.getDatabase()).isEqualTo("r2dbc");
+        assertThat(configuration.getZeroDateOption()).isEqualTo(ZeroDateOption.USE_ROUND);
+        assertThat(configuration.isTcpKeepAlive()).isTrue();
+        assertThat(configuration.isTcpNoDelay()).isTrue();
+        assertThat(configuration.getServerZoneId()).isEqualTo(ZoneId.of("Asia/Tokyo"));
+        assertThat(configuration.getPreferPrepareStatement()).isExactlyInstanceOf(AllTruePredicate.class);
+        assertThat(configuration.getExtensions()).isEqualTo(Extensions.from(Collections.emptyList(), true));
+
+        assertThat(configuration.getSsl().getSslMode()).isEqualTo(SslMode.VERIFY_IDENTITY);
+        assertThat(configuration.getSsl().getTlsVersion()).isEqualTo(new String[] {"TLSv1.3", "TLSv1.2"});
+        assertThat(configuration.getSsl().getSslCa()).isEqualTo("/path/to/ca.pem");
+        assertThat(configuration.getSsl().getSslKey()).isEqualTo("/path/to/client-key.pem");
+        assertThat(configuration.getSsl().getSslCert()).isEqualTo("/path/to/client-cert.pem");
+        assertThat(configuration.getSsl().getSslKeyPassword()).isEqualTo("ssl123456");
+        assertThat(configuration.getSsl().getSslHostnameVerifier())
+            .isExactlyInstanceOf(MyHostnameVerifier.class);
+        assertThatExceptionOfType(MockException.class)
+            .isThrownBy(() -> configuration.getSsl().customizeSslContext(SslContextBuilder.forClient()));
+    }
+
+    @Test
+    void invalidProgrammatic() {
+        assertThatIllegalStateException().isThrownBy(() -> MySqlConnectionFactoryProvider.setup(ConnectionFactoryOptions.builder()
+            .option(DRIVER, "mysql")
             .option(PORT, 3307)
             .option(USER, "root")
             .option(PASSWORD, "123456")
@@ -154,41 +183,96 @@ class MySqlConnectionFactoryProviderTest {
             .option(DATABASE, "r2dbc")
             .option(Option.valueOf("zeroDate"), "use_round")
             .option(Option.valueOf("sslMode"), "verify_identity")
-            .option(Option.valueOf("tlsVersion"), "TLSv1.2,TLSv1.3")
+            .option(Option.valueOf("tlsVersion"), "TLSv1.3,TLSv1.2")
             .option(Option.valueOf("sslCa"), "/path/to/ca.pem")
             .option(Option.valueOf("sslKey"), "/path/to/client-key.pem")
             .option(Option.valueOf("sslCert"), "/path/to/client-cert.pem")
             .option(Option.valueOf("sslKeyPassword"), "ssl123456")
             .option(Option.valueOf("tcpKeepAlive"), "true")
             .option(Option.valueOf("tcpNoDelay"), "true")
-            .build();
-
-        assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);
+            .build()))
+            .withMessageContaining("host");
     }
 
     @Test
-    void invalidProgrammatic() {
-        assertThat(assertThrows(IllegalArgumentException.class, () -> ConnectionFactories.get(ConnectionFactoryOptions.builder()
+    void validProgrammaticUnixSocket() {
+        Assert<?, String> domain = assertThat("/path/to/mysql.sock");
+        Assert<?, Boolean> isHost = assertThat(false);
+        Assert<?, SslMode> sslMode = assertThat(SslMode.DISABLED);
+
+        MySqlConnectionConfiguration configuration = MySqlConnectionFactoryProvider.setup(ConnectionFactoryOptions.builder()
             .option(DRIVER, "mysql")
             .option(Option.valueOf("unixSocket"), "/path/to/mysql.sock")
             .option(USER, "root")
             .option(SSL, true)
-            .build()))
-            .getMessage())
-            .contains("sslMode");
+            .build());
+
+        domain.isEqualTo(configuration.getDomain());
+        isHost.isEqualTo(configuration.isHost());
+        sslMode.isEqualTo(configuration.getSsl().getSslMode());
 
         for (SslMode mode : SslMode.values()) {
-            if (mode.startSsl()) {
-                assertThat(assertThrows(IllegalArgumentException.class, () -> ConnectionFactories.get(ConnectionFactoryOptions.builder()
-                    .option(DRIVER, "mysql")
-                    .option(Option.valueOf("unixSocket"), "/path/to/mysql.sock")
-                    .option(USER, "root")
-                    .option(Option.valueOf("sslMode"), mode.name().toLowerCase())
-                    .build()))
-                    .getMessage())
-                    .contains("sslMode");
-            }
+            configuration = MySqlConnectionFactoryProvider.setup(ConnectionFactoryOptions.builder()
+                .option(DRIVER, "mysql")
+                .option(Option.valueOf("unixSocket"), "/path/to/mysql.sock")
+                .option(USER, "root")
+                .option(Option.valueOf("sslMode"), mode.name().toLowerCase())
+                .build());
+
+            domain.isEqualTo(configuration.getDomain());
+            isHost.isEqualTo(configuration.isHost());
+            sslMode.isEqualTo(configuration.getSsl().getSslMode());
         }
+
+        configuration = MySqlConnectionFactoryProvider.setup(ConnectionFactoryOptions.builder()
+            .option(DRIVER, "mysql")
+            .option(Option.valueOf("unixSocket"), "/path/to/mysql.sock")
+            .option(HOST, "127.0.0.1")
+            .option(PORT, 3307)
+            .option(USER, "root")
+            .option(PASSWORD, "123456")
+            .option(SSL, true)
+            .option(Option.valueOf(CONNECT_TIMEOUT.name()), Duration.ofSeconds(3).toString())
+            .option(DATABASE, "r2dbc")
+            .option(Option.valueOf("serverZoneId"), "Asia/Tokyo")
+            .option(Option.valueOf("useServerPrepareStatement"), AllTruePredicate.class.getName())
+            .option(Option.valueOf("zeroDate"), "use_round")
+            .option(Option.valueOf("sslMode"), "verify_identity")
+            .option(Option.valueOf("tlsVersion"), "TLSv1.3,TLSv1.2")
+            .option(Option.valueOf("sslCa"), "/path/to/ca.pem")
+            .option(Option.valueOf("sslKey"), "/path/to/client-key.pem")
+            .option(Option.valueOf("sslCert"), "/path/to/client-cert.pem")
+            .option(Option.valueOf("sslKeyPassword"), "ssl123456")
+            .option(Option.valueOf("sslHostnameVerifier"), MyHostnameVerifier.class.getName())
+            .option(Option.valueOf("sslContextBuilderCustomizer"), SslCustomizer.class.getName())
+            .option(Option.valueOf("tcpKeepAlive"), "true")
+            .option(Option.valueOf("tcpNoDelay"), "true")
+            .build());
+
+        assertThat(configuration.getDomain()).isEqualTo("/path/to/mysql.sock");
+        assertThat(configuration.isHost()).isFalse();
+        assertThat(configuration.getPort()).isEqualTo(3306);
+        assertThat(configuration.getUser()).isEqualTo("root");
+        assertThat(configuration.getPassword()).isEqualTo("123456");
+        assertThat(configuration.getConnectTimeout()).isEqualTo(Duration.ofSeconds(3));
+        assertThat(configuration.getDatabase()).isEqualTo("r2dbc");
+        assertThat(configuration.getZeroDateOption()).isEqualTo(ZeroDateOption.USE_ROUND);
+        assertThat(configuration.isTcpKeepAlive()).isTrue();
+        assertThat(configuration.isTcpNoDelay()).isTrue();
+        assertThat(configuration.getServerZoneId()).isEqualTo(ZoneId.of("Asia/Tokyo"));
+        assertThat(configuration.getPreferPrepareStatement()).isExactlyInstanceOf(AllTruePredicate.class);
+        assertThat(configuration.getExtensions()).isEqualTo(Extensions.from(Collections.emptyList(), true));
+
+        assertThat(configuration.getSsl().getSslMode()).isEqualTo(SslMode.DISABLED);
+        assertThat(configuration.getSsl().getTlsVersion()).isEmpty();
+        assertThat(configuration.getSsl().getSslCa()).isNull();
+        assertThat(configuration.getSsl().getSslKey()).isNull();
+        assertThat(configuration.getSsl().getSslCert()).isNull();
+        assertThat(configuration.getSsl().getSslKeyPassword()).isNull();
+        assertThat(configuration.getSsl().getSslHostnameVerifier()).isNull();
+        SslContextBuilder sslContextBuilder = SslContextBuilder.forClient();
+        assertThat(sslContextBuilder)
+            .isSameAs(configuration.getSsl().customizeSslContext(sslContextBuilder));
     }
 
     @Test
@@ -250,19 +334,40 @@ class MySqlConnectionFactoryProviderTest {
 
     @Test
     void invalidServerPreparing() {
-        assertThrows(IllegalArgumentException.class, () -> ConnectionFactories.get(ConnectionFactoryOptions.builder()
+        assertThatIllegalArgumentException().isThrownBy(() -> ConnectionFactories.get(ConnectionFactoryOptions.builder()
             .option(DRIVER, "mysql")
             .option(HOST, "127.0.0.1")
             .option(USER, "root")
             .option(USE_SERVER_PREPARE_STATEMENT, NotPredicate.class.getTypeName())
             .build()));
 
-        assertThrows(IllegalArgumentException.class, () -> ConnectionFactories.get(ConnectionFactoryOptions.builder()
+        assertThatIllegalArgumentException().isThrownBy(() -> ConnectionFactories.get(ConnectionFactoryOptions.builder()
             .option(DRIVER, "mysql")
             .option(HOST, "127.0.0.1")
             .option(USER, "root")
             .option(USE_SERVER_PREPARE_STATEMENT, NotPredicate.class.getPackage() + "NonePredicate")
             .build()));
+    }
+}
+
+final class MockException extends RuntimeException {
+
+    static final MockException INSTANCE = new MockException();
+}
+
+final class SslCustomizer implements Function<SslContextBuilder, SslContextBuilder> {
+
+    @Override
+    public SslContextBuilder apply(SslContextBuilder sslContextBuilder) {
+        throw MockException.INSTANCE;
+    }
+}
+
+final class MyHostnameVerifier implements HostnameVerifier {
+
+    @Override
+    public boolean verify(String s, SSLSession sslSession) {
+        return true;
     }
 }
 

--- a/src/test/java/dev/miku/r2dbc/mysql/json/JacksonCodecRegistrar.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/json/JacksonCodecRegistrar.java
@@ -37,6 +37,16 @@ public final class JacksonCodecRegistrar implements CodecRegistrar {
     }
 
     @Override
+    public int hashCode() {
+        return 1;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof JacksonCodecRegistrar;
+    }
+
+    @Override
     public String toString() {
         return "JacksonCodecRegistrar{}";
     }


### PR DESCRIPTION
It make a sense for robustness of `MySqlConnectionFactoryProvider`. Inspired by [`r2dbc-postgresql`](https://github.com/pgjdbc/r2dbc-postgresql).

It make some change as follow:

- Change the ordering of TLS versions.
- Change sslKeyAndCert to sslCertAndKey.
- Add comment for factory provider.
