### PR TITLE
Add cache supports

### DIFF
--- a/src/main/java/dev/miku/r2dbc/mysql/Binding.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/Binding.java
@@ -20,7 +20,6 @@ import dev.miku.r2dbc.mysql.message.client.PreparedExecuteMessage;
 import dev.miku.r2dbc.mysql.message.client.TextQueryMessage;
 
 import java.util.Arrays;
-import java.util.function.Consumer;
 
 /**
  * A collection of {@link Parameter} for one bind invocation of a parametrized statement.
@@ -70,8 +69,8 @@ final class Binding {
         return new PreparedExecuteMessage(statementId, immediate, drainValues());
     }
 
-    TextQueryMessage toTextMessage(TextQuery query, Consumer<String> sqlProceed) {
-        return new TextQueryMessage(query.getSqlParts(), drainValues(), sqlProceed);
+    TextQueryMessage toTextMessage(TextQuery query) {
+        return new TextQueryMessage(query.getSqlParts(), drainValues());
     }
 
     /**

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -16,7 +16,6 @@
 
 package dev.miku.r2dbc.mysql;
 
-import dev.miku.r2dbc.mysql.cache.Caches;
 import dev.miku.r2dbc.mysql.constant.SslMode;
 import dev.miku.r2dbc.mysql.constant.ZeroDateOption;
 import dev.miku.r2dbc.mysql.extension.Extension;
@@ -689,16 +688,14 @@ public final class MySqlConnectionConfiguration {
          * Configures the maximum size of the {@link Query} parsing cache. Usually it should be power of
          * two.  Default to {@code 0}. Driver will use unbounded cache if size is less than {@code 0}.
          * <p>
-         * Notice: the cache is using EL cache (the PACELC theorem) which provider better performance.
+         * Notice: the cache is using EL model (the PACELC theorem) which provider better performance.
          * That means it is an elastic cache. So this size is not a hard-limit. It should be over 16 in average.
          *
          * @param queryCacheSize the above size, {@code 0} means no cache, {@code -1} means unbounded cache.
          * @return this {@link Builder}.
-         * @throws IllegalArgumentException if {@code queryCacheSize} is greater than {@link Caches#MAX_CAPACITY}.
          * @since 0.8.3
          */
         public Builder queryCacheSize(int queryCacheSize) {
-            require(queryCacheSize <= Caches.MAX_CAPACITY, "queryCacheSize must not be too large");
             this.queryCacheSize = queryCacheSize;
             return this;
         }
@@ -710,16 +707,16 @@ public final class MySqlConnectionConfiguration {
          * It will be used only if using server-preparing for parametrized statements, i.e. the
          * {@link #useServerPrepareStatement} is set.
          * <p>
-         * Notice: the cache is using EL model (the PACELC theorem) which provider better performance.
-         * That means it is an elastic cache. So this size is not a hard-limit. It should be over 16 in average.
+         * Notice: the cache is using EC model (the PACELC theorem) for ensure consistency. Consistency
+         * is very important because MySQL contains a hard limit of all server-prepared statements which
+         * has been opened, see also {@code max_prepared_stmt_count}. And, the cache is one-to-one
+         * connection, which means it will not work on thread-concurrency.
          *
          * @param prepareCacheSize the above size, {@code 0} means no cache, {@code -1} means unbounded cache.
          * @return this {@link Builder}.
-         * @throws IllegalArgumentException if {@code prepareCacheSize} is greater than {@link Caches#MAX_CAPACITY}.
          * @since 0.8.3
          */
         public Builder prepareCacheSize(int prepareCacheSize) {
-            require(prepareCacheSize <= Caches.MAX_CAPACITY, "prepareCacheSize must not be too large");
             this.prepareCacheSize = prepareCacheSize;
             return this;
         }

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactory.java
@@ -24,7 +24,6 @@ import dev.miku.r2dbc.mysql.codec.Codecs;
 import dev.miku.r2dbc.mysql.codec.CodecsBuilder;
 import dev.miku.r2dbc.mysql.constant.SslMode;
 import dev.miku.r2dbc.mysql.extension.CodecRegistrar;
-import dev.miku.r2dbc.mysql.message.server.ServerMessage;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.r2dbc.spi.ConnectionFactory;

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -171,6 +171,20 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     public static final Option<Object> USE_SERVER_PREPARE_STATEMENT = Option.valueOf("useServerPrepareStatement");
 
     /**
+     * Option to set the maximum size of the {@link Query} parsing cache.  Default to {@code 256}.
+     *
+     * @since 0.8.3
+     */
+    public static final Option<Integer> PREPARE_CACHE_SIZE = Option.valueOf("prepareCacheSize");
+
+    /**
+     * Option to set the maximum size of the server-preparing cache.  Default to {@code 0}.
+     *
+     * @since 0.8.3
+     */
+    public static final Option<Integer> QUERY_CACHE_SIZE = Option.valueOf("queryCacheSize");
+
+    /**
      * Enable/Disable auto-detect driver extensions.
      *
      * @since 0.8.2
@@ -228,6 +242,10 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
                 builder.useClientPrepareStatement();
             }
         }, builder::useServerPrepareStatement);
+        mapper.from(QUERY_CACHE_SIZE).asInt()
+            .into(builder::queryCacheSize);
+        mapper.from(PREPARE_CACHE_SIZE).asInt()
+            .into(builder::prepareCacheSize);
         mapper.from(AUTODETECT_EXTENSIONS).asBoolean()
             .into(builder::autodetectExtensions);
         mapper.from(CONNECT_TIMEOUT).asInstance(Duration.class, Duration::parse)

--- a/src/main/java/dev/miku/r2dbc/mysql/PrepareQuery.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/PrepareQuery.java
@@ -58,12 +58,12 @@ final class PrepareQuery extends Query {
         return index;
     }
 
-    Set<String> getParameterNames() {
-        return nameKeyedIndex.keySet();
-    }
-
     String getSql() {
         return sql;
+    }
+
+    Set<String> getParameterNames() {
+        return nameKeyedIndex.keySet();
     }
 
     @Override

--- a/src/main/java/dev/miku/r2dbc/mysql/PrepareSimpleStatement.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/PrepareSimpleStatement.java
@@ -16,6 +16,7 @@
 
 package dev.miku.r2dbc.mysql;
 
+import dev.miku.r2dbc.mysql.cache.PrepareCache;
 import dev.miku.r2dbc.mysql.client.Client;
 import dev.miku.r2dbc.mysql.codec.Codecs;
 import reactor.core.publisher.Flux;
@@ -32,15 +33,21 @@ final class PrepareSimpleStatement extends SimpleStatementSupport {
 
     private static final List<Binding> BINDINGS = Collections.singletonList(new Binding(0));
 
+    private final PrepareCache<Integer> prepareCache;
+
     private int fetchSize = 0;
 
-    PrepareSimpleStatement(Client client, Codecs codecs, ConnectionContext context, String sql) {
+    PrepareSimpleStatement(
+        Client client, Codecs codecs, ConnectionContext context,
+        String sql, PrepareCache<Integer> prepareCache
+    ) {
         super(client, codecs, context, sql);
+        this.prepareCache = prepareCache;
     }
 
     @Override
     public Flux<MySqlResult> execute() {
-        return QueryFlow.execute(client, sql, BINDINGS, fetchSize)
+        return QueryFlow.execute(client, sql, BINDINGS, fetchSize, prepareCache)
             .map(messages -> new MySqlResult(true, codecs, context, generatedKeyName, messages));
     }
 

--- a/src/main/java/dev/miku/r2dbc/mysql/Query.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/Query.java
@@ -121,7 +121,7 @@ abstract class Query {
             return new PrepareQuery(parsedSql, wrap(nameKeyedParams, anyName), paramCount);
         } else {
             sqlParts.add(subStr(sql, lastParamEnd, length));
-            return new TextQuery(wrap(nameKeyedParams, anyName), sqlParts);
+            return new TextQuery(sql, wrap(nameKeyedParams, anyName), sqlParts);
         }
     }
 

--- a/src/main/java/dev/miku/r2dbc/mysql/Query.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/Query.java
@@ -51,17 +51,10 @@ abstract class Query {
         // ONLY FOR PREPARE: Parsed SQL builder, if SQL does not contains named-parameter, it will always be null.
         StringBuilder sqlBuilder = null;
         // ONLY FOR TEXT: SQL parts split by parameters.
-        List<String> sqlParts;
-
-        if (prepare) {
-            // Prepare parsing, no need collect parts of SQL.
-            sqlParts = Collections.emptyList();
-        } else {
-            sqlParts = new ArrayList<>();
-        }
+        List<String> sqlParts = prepare ? null : new ArrayList<>();
 
         while (offset >= 0 && offset < length) {
-            if (!prepare) {
+            if (sqlParts != null) {
                 sqlParts.add(subStr(sql, lastParamEnd, offset));
             }
             ++paramCount;
@@ -113,7 +106,7 @@ abstract class Query {
             }
         }
 
-        if (prepare) {
+        if (sqlParts == null) {
             String parsedSql;
 
             if (sqlBuilder == null) {
@@ -233,10 +226,6 @@ abstract class Query {
     }
 
     private static String subStr(String sql, int start, int end) {
-        if (start == end) {
-            return "";
-        } else {
-            return sql.substring(start, end);
-        }
+        return start == end ? "" : sql.substring(start, end);
     }
 }

--- a/src/main/java/dev/miku/r2dbc/mysql/TextQuery.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/TextQuery.java
@@ -28,15 +28,19 @@ import static dev.miku.r2dbc.mysql.util.AssertUtils.requireNonNull;
  */
 final class TextQuery extends Query {
 
+    private final String sql;
+
     private final Map<String, ParameterIndex> nameKeyedIndex;
 
     private final List<String> sqlParts;
 
-    TextQuery(Map<String, ParameterIndex> nameKeyedIndex, List<String> sqlParts) {
+    TextQuery(String sql, Map<String, ParameterIndex> nameKeyedIndex, List<String> sqlParts) {
+        requireNonNull(sql, "originSql must not be null");
         requireNonNull(nameKeyedIndex, "named parameter map must not be null");
         requireNonNull(sqlParts, "sql parts must not be null");
         require(sqlParts.size() > 1, "sql parts need least 2 parts");
 
+        this.sql = sql;
         this.nameKeyedIndex = nameKeyedIndex;
         this.sqlParts = sqlParts;
     }
@@ -55,6 +59,10 @@ final class TextQuery extends Query {
         }
 
         return index;
+    }
+
+    String getSql() {
+        return sql;
     }
 
     /**

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/Caches.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/Caches.java
@@ -26,11 +26,6 @@ import static dev.miku.r2dbc.mysql.util.AssertUtils.requireNonNull;
 public final class Caches {
 
     /**
-     * The maximum capacity of bounded caches.
-     */
-    public static final int MAX_CAPACITY = 1073741824; // Integer.MIN_VALUE >>> 1
-
-    /**
      * Create a new {@link QueryCache} by cache configuration.
      *
      * @param capacity the capacity of {@link QueryCache}.
@@ -41,7 +36,7 @@ public final class Caches {
     public static <T> QueryCache<T> createQueryCache(int capacity, Function<String, T> mapping) {
         requireNonNull(mapping, "mapping must not be null");
 
-        if (capacity > 0 && capacity <= MAX_CAPACITY) {
+        if (capacity > 0 && capacity < Integer.MAX_VALUE) {
             return new QueryBoundedCache<>(capacity, mapping);
         } else if (capacity == 0) {
             return new QueryDisabledCache<>(mapping);
@@ -58,7 +53,7 @@ public final class Caches {
      * @return the above {@link PrepareCache}.
      */
     public static <T> PrepareCache<T> createPrepareCache(int capacity) {
-        if (capacity > 0 && capacity <= MAX_CAPACITY) {
+        if (capacity > 0 && capacity < Integer.MAX_VALUE) {
             return new PrepareBoundedCache<>(capacity);
         } else if (capacity == 0) {
             return new PrepareDisabledCache<>();

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/Caches.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/Caches.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import java.util.function.Function;
+
+import static dev.miku.r2dbc.mysql.util.AssertUtils.requireNonNull;
+
+/**
+ * An utility for create caches from configuration.
+ */
+public final class Caches {
+
+    /**
+     * The maximum capacity of bounded caches.
+     */
+    public static final int MAX_CAPACITY = 1073741824; // Integer.MIN_VALUE >>> 1
+
+    /**
+     * Create a new {@link QueryCache} by cache configuration.
+     *
+     * @param capacity the capacity of {@link QueryCache}.
+     * @param mapping  the parsing function.
+     * @param <T>      the type of cache value, which is usually the type of parsed result.
+     * @return the above {@link QueryCache}.
+     */
+    public static <T> QueryCache<T> createQueryCache(int capacity, Function<String, T> mapping) {
+        requireNonNull(mapping, "mapping must not be null");
+
+        if (capacity > 0 && capacity <= MAX_CAPACITY) {
+            return new QueryBoundedCache<>(capacity, mapping);
+        } else if (capacity == 0) {
+            return new QueryDisabledCache<>(mapping);
+        } else {
+            return new QueryUnboundedCache<>(mapping);
+        }
+    }
+
+    /**
+     * Create a new {@link PrepareCache} by cache configuration.
+     *
+     * @param capacity the capacity of {@link PrepareCache}.
+     * @param <T>      the type of cache value, which is usually the parsed statement ID.
+     * @return the above {@link PrepareCache}.
+     */
+    public static <T> PrepareCache<T> createPrepareCache(int capacity) {
+        if (capacity > 0 && capacity <= MAX_CAPACITY) {
+            return new PrepareBoundedCache<>(capacity);
+        } else if (capacity == 0) {
+            return new PrepareDisabledCache<>();
+        } else {
+            return new PrepareUnboundedCache<>();
+        }
+    }
+
+    /**
+     * Returns the smallest power of two greater than or equal to {@code x}. This
+     * is equivalent to {@code pow(2, ceil(log2(x)))}.
+     * <p>
+     * From Hacker's Delight, Chapter 3, Harry S. Warren Jr.
+     *
+     * @param x between 0 and 1073741824 (inclusive).
+     * @return the closest power-of-two at or higher than the given value {@code x}.
+     */
+    static int ceilingPowerOfTwo(int x) {
+        return 1 << -Integer.numberOfLeadingZeros(x - 1);
+    }
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/FreqSketch.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/FreqSketch.java
@@ -63,6 +63,8 @@ final class FreqSketch {
 
     private static final long ONE_MASK = 0x1111111111111111L;
 
+    private static final int MAX_SIZE = Integer.MIN_VALUE >>> 1;
+
     private final long[] table;
 
     private final int tableMask;
@@ -72,15 +74,14 @@ final class FreqSketch {
     private int size;
 
     /**
-     * Initializes and increases the capacity of this {@code FreqSketch} instance, if necessary,
-     * to ensure that it can accurately estimate the popularity of elements given the maximum size of
-     * the cache. This operation forgets all previous counts when resizing.
+     * Construct {@code FreqSketch} with a fixed size.
      *
-     * @param capacity the maximum size of the cache, between 1 and 1073741824 (inclusive).
+     * @param maxSize the fixed size of the sketch, at least 1.
      */
-    FreqSketch(int capacity) {
-        require(capacity > 0 && capacity <= Caches.MAX_CAPACITY, "capacity must be a valid integer");
+    FreqSketch(int maxSize) {
+        require(maxSize > 0, "maxSize must be a positive integer");
 
+        int capacity = Math.min(maxSize, MAX_SIZE);
         int sampling = capacity * 10;
 
         this.table = new long[Caches.ceilingPowerOfTwo(capacity)];

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/FreqSketch.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/FreqSketch.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import static dev.miku.r2dbc.mysql.util.AssertUtils.require;
+
+/**
+ * A probabilistic set for estimating the popularity (frequency) of an element within an
+ * access frequency based time window. The maximum frequency of an element is limited
+ * to 15 (4-bits) and an aging process periodically halves the popularity of all elements.
+ * <p>
+ * Notice: it's using lots of magic numbers, and should not to change these numbers.
+ */
+final class FreqSketch {
+
+    /*
+     * This is a SLIGHTLY altered version of Caffeine's [1] implementation.
+     *
+     * This class maintains a 4-bit CountMinSketch [2] with periodic aging to provide the popularity
+     * history for the TinyLfu admission policy [3]. The time and space efficiency of the sketch
+     * allows it to cheaply estimate the frequency of an entry in a stream of cache access events.
+     *
+     * The counter matrix is represented as a single dimensional array holding 16 counters per slot. A
+     * fixed depth of four balances the accuracy and cost, resulting in a width of four times the
+     * length of the array. To retain an accurate estimation the array's length equals the maximum
+     * number of entries in the cache, increased to the closest power-of-two to exploit more efficient
+     * bit masking. This configuration results in a confidence of 93.75% and error bound of e / width.
+     *
+     * The frequency of all entries is aged periodically using a sampling window based on the maximum
+     * number of entries in the cache. This is referred to as the reset operation by TinyLfu and keeps
+     * the sketch fresh by dividing all counters by two and subtracting based on the number of odd
+     * counters found. The O(n) cost of aging is amortized, ideal for hardware pre-fetching, and uses
+     * inexpensive bit manipulations per array location.
+     *
+     * [1] Caffeine: a high performance, near optimal caching library based on Java 8.
+     * https://github.com/ben-manes/caffeine
+     * [2] An Improved Data Stream Summary: The Count-Min Sketch and its Applications
+     * http://dimacs.rutgers.edu/~graham/pubs/papers/cm-full.pdf
+     * [3] TinyLFU: A Highly Efficient Cache Admission Policy
+     * https://dl.acm.org/citation.cfm?id=3149371
+     */
+
+    /**
+     * A mixture of seeds from FNV-1a, CityHash, and Murmur3.
+     */
+    private static final long[] SEED = {0xc3a5c85c97cb3127L, 0xb492b66fbe98f273L, 0x9ae16a3b2f90404fL, 0xcbf29ce484222325L};
+
+    private static final long RESET_MASK = 0x7777777777777777L;
+
+    private static final long ONE_MASK = 0x1111111111111111L;
+
+    private final long[] table;
+
+    private final int tableMask;
+
+    private final int sampling;
+
+    private int size;
+
+    /**
+     * Initializes and increases the capacity of this {@code FreqSketch} instance, if necessary,
+     * to ensure that it can accurately estimate the popularity of elements given the maximum size of
+     * the cache. This operation forgets all previous counts when resizing.
+     *
+     * @param capacity the maximum size of the cache, between 1 and 1073741824 (inclusive).
+     */
+    FreqSketch(int capacity) {
+        require(capacity > 0 && capacity <= Caches.MAX_CAPACITY, "capacity must be a valid integer");
+
+        int sampling = capacity * 10;
+
+        this.table = new long[Caches.ceilingPowerOfTwo(capacity)];
+        this.tableMask = table.length - 1;
+        this.sampling = sampling > 0 ? sampling : Integer.MAX_VALUE;
+        this.size = 0;
+    }
+
+    /**
+     * Returns the estimated number of occurrences of an element, up to the maximum (15).
+     *
+     * @param hashCode the hashCode of element to count occurrences of
+     * @return the estimated number of occurrences of the element; possibly zero but never negative
+     */
+    int frequency(int hashCode) {
+        int hash = spread(hashCode);
+        int start = (hash & 3) << 2;
+        int frequency = Integer.MAX_VALUE;
+
+        for (int i = 0; i < 4; i++) {
+            int index = indexOf(hash, i);
+            frequency = Math.min(frequency, (int) ((table[index] >>> ((start + i) << 2)) & 0xfL));
+        }
+        return frequency;
+    }
+
+    /**
+     * Increments the popularity of the element if it does not exceed the maximum (15). The popularity
+     * of all elements will be periodically down sampled when the observed events exceeds a threshold.
+     * This process provides a frequency aging to allow expired long term entries to fade away.
+     *
+     * @param hashCode the hashCode of element to add
+     */
+    void increment(int hashCode) {
+        int hash = spread(hashCode);
+        int start = (hash & 3) << 2;
+
+        // Loop unrolling improves throughput by 5m ops/s
+        int index0 = indexOf(hash, 0);
+        int index1 = indexOf(hash, 1);
+        int index2 = indexOf(hash, 2);
+        int index3 = indexOf(hash, 3);
+
+        boolean added = incrementAt(index0, start);
+        added |= incrementAt(index1, start + 1);
+        added |= incrementAt(index2, start + 2);
+        added |= incrementAt(index3, start + 3);
+
+        if (added && (++size == sampling)) {
+            reset();
+        }
+    }
+
+    /**
+     * Increments the specified counter by 1 if it is not already at the maximum value (15).
+     *
+     * @param i the table index (16 counters)
+     * @param j the counter to increment
+     * @return if incremented
+     */
+    private boolean incrementAt(int i, int j) {
+        int offset = j << 2;
+        long mask = (0xfL << offset);
+        if ((table[i] & mask) != mask) {
+            table[i] += (1L << offset);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Reduces every counter by half of its original value.
+     */
+    private void reset() {
+        int count = 0;
+        for (int i = 0; i < table.length; i++) {
+            count += Long.bitCount(table[i] & ONE_MASK);
+            table[i] = (table[i] >>> 1) & RESET_MASK;
+        }
+        size = (size >>> 1) - (count >>> 2);
+    }
+
+    /**
+     * Returns the table index for the counter at the specified depth.
+     *
+     * @param item the element's hash
+     * @param i    the counter depth
+     * @return the table index
+     */
+    private int indexOf(int item, int i) {
+        long hash = (item + SEED[i]) * SEED[i];
+        return ((int) (hash + (hash >>> 32))) & tableMask;
+    }
+
+    /**
+     * Applies a supplemental hash function to a given hashCode, which defends against poor quality
+     * hash functions.
+     */
+    private static int spread(int x) {
+        x = ((x >>> 16) ^ x) * 0x45d9f3b;
+        x = ((x >>> 16) ^ x) * 0x45d9f3b;
+        return (x >>> 16) ^ x;
+    }
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/Lru.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/Lru.java
@@ -54,7 +54,14 @@ final class Lru<T> {
     }
 
     void refresh(Node<T> node) {
-        Node<T> prev = node.prev, next = node.next, head = this.head;
+        Node<T> head = this.head;
+
+        if (node == head) {
+            // No need refresh.
+            return;
+        }
+
+        Node<T> prev = node.prev, next = node.next;
 
         if (head == null) {
             throw new IllegalStateException("LRU must not be empty");
@@ -69,7 +76,7 @@ final class Lru<T> {
 
         if (node == tail) {
             // Must be pointer compare.
-            tail = prev;
+            this.tail = prev;
         }
 
         node.prev = null;

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/Lru.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/Lru.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import reactor.util.annotation.Nullable;
+
+import static dev.miku.r2dbc.mysql.util.AssertUtils.require;
+
+/**
+ * A minimal implementation of LRU without hashing map.
+ * <p>
+ * If want to use, should take with a external hash map.
+ */
+final class Lru<T> {
+
+    static final int WINDOW = 1;
+
+    static final int PROBATION = 2;
+
+    static final int PROTECTION = 3;
+
+    private final int limit;
+
+    private final int eigenvalue;
+
+    @Nullable
+    private Node<T> head;
+
+    @Nullable
+    private Node<T> tail;
+
+    private int size;
+
+    Lru(int limit, int eigenvalue) {
+        require(limit > 0, "limit must be greater than 0");
+        require(eigenvalue > 0, "eigenvalue must be greater than 0");
+
+        this.limit = limit;
+        this.eigenvalue = eigenvalue;
+    }
+
+    void refresh(Node<T> node) {
+        Node<T> prev = node.prev, next = node.next, head = this.head;
+
+        if (head == null) {
+            throw new IllegalStateException("LRU must not be empty");
+        }
+
+        if (prev != null) {
+            prev.next = next;
+        }
+        if (next != null) {
+            next.prev = prev;
+        }
+
+        if (node == tail) {
+            // Must be pointer compare.
+            tail = prev;
+        }
+
+        node.prev = null;
+        node.next = head;
+        head.prev = node;
+        this.head = node;
+    }
+
+    @Nullable
+    Node<T> push(Node<T> node) {
+        Node<T> head = this.head;
+
+        node.lru = this.eigenvalue;
+        node.prev = null;
+        node.next = head;
+
+        if (head == null) {
+            this.tail = node;
+        } else {
+            head.prev = node;
+        }
+
+        this.head = node;
+
+        if (size < limit) {
+            ++size;
+            return null;
+        }
+
+        Node<T> unlink = this.tail;
+        Node<T> tail;
+
+        if (unlink == null || (tail = unlink.prev) == null) {
+            throw new IllegalStateException("LRU must be contains least 2 elements when choose an unlink element");
+        }
+
+        tail.next = null;
+        this.tail = tail;
+
+        unlink.reInit();
+
+        return unlink;
+    }
+
+    @Nullable
+    Lru.Node<T> nextEviction() {
+        return size < limit ? null : tail;
+    }
+
+    void remove(Node<T> node) {
+        Node<T> prev = node.prev, next = node.next, head = this.head, tail = this.tail;
+
+        if (head == null || tail == null) {
+            throw new IllegalStateException("LRU must not be empty");
+        }
+
+        if (prev != null) {
+            prev.next = next;
+        }
+        if (next != null) {
+            next.prev = prev;
+        }
+
+        if (node == tail) {
+            // Must be pointer compare.
+            this.tail = prev;
+        }
+        if (node == head) {
+            this.head = next;
+        }
+
+        --size;
+        node.reInit();
+    }
+
+    @Override
+    public String toString() {
+        Node<T> head = this.head, tail = this.tail;
+
+        if (head == null || tail == null) {
+            return "[]";
+        }
+
+        StringBuilder builder = new StringBuilder().append('[');
+
+        for (Node<T> ptr = head; ptr != null && ptr != tail; ptr = ptr.next) {
+            builder.append(ptr.value).append(',').append(' ');
+        }
+
+        return builder.append(tail.value).append(']').toString();
+    }
+
+    static final class Node<T> {
+
+        private final String key;
+
+        private final T value;
+
+        private int lru;
+
+        @Nullable
+        private Node<T> prev;
+
+        @Nullable
+        private Node<T> next;
+
+        Node(String key, T value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        int getLru() {
+            return lru;
+        }
+
+        String getKey() {
+            return key;
+        }
+
+        T getValue() {
+            return value;
+        }
+
+        private void reInit() {
+            lru = 0;
+            prev = next = null;
+        }
+    }
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/PrepareBoundedCache.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/PrepareBoundedCache.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import java.util.HashMap;
+import java.util.function.Consumer;
+
+/**
+ * A bounded implementation of {@link PrepareCache} that uses synchronized methods to ensure
+ * correctness, even it should not be used thread-concurrently.
+ */
+final class PrepareBoundedCache<T> extends HashMap<String, Lru.Node<T>> implements PrepareCache<T> {
+
+    private final FreqSketch sketch;
+
+    private final Lru<T> window;
+
+    private final Lru<T> probation;
+
+    private final Lru<T> protection;
+
+    PrepareBoundedCache(int capacity) {
+        int windowSize = Math.max(1, capacity / 100);
+        int protectionSize = Math.max(1, (int) ((capacity - windowSize) * 0.8));
+        int probationSize = Math.max(1, capacity - protectionSize - windowSize);
+
+        this.sketch = new FreqSketch(windowSize + protectionSize + probationSize);
+        this.window = new Lru<>(windowSize, Lru.WINDOW);
+        this.probation = new Lru<>(probationSize, Lru.PROBATION);
+        this.protection = new Lru<>(protectionSize, Lru.PROTECTION);
+    }
+
+    @Override
+    public synchronized T getIfPresent(String key) {
+        Lru.Node<T> node = super.get(key);
+
+        if (node == null) {
+            return null;
+        }
+
+        drainRead(node);
+        return node.getValue();
+    }
+
+    @Override
+    public synchronized boolean putIfAbsent(String key, T value, Consumer<T> evict) {
+        Lru.Node<T> wantAdd = new Lru.Node<>(key, value);
+        Lru.Node<T> present = super.putIfAbsent(key, wantAdd);
+
+        if (present == null) {
+            drainAdded(wantAdd, evict);
+            return true;
+        }
+
+        drainRead(present);
+        return false;
+    }
+
+    private void drainRead(Lru.Node<T> node) {
+        sketch.increment(node.getKey().hashCode());
+
+        switch (node.getLru()) {
+            case Lru.WINDOW:
+                window.refresh(node);
+                break;
+            case Lru.PROBATION:
+                probation.remove(node);
+                Lru.Node<T> evicted = protection.push(node);
+
+                if (evicted != null) {
+                    // This element must be protected.
+                    // Result should be null because probation has removed one element.
+                    probation.push(evicted);
+                }
+                break;
+            case Lru.PROTECTION:
+                protection.refresh(node);
+                break;
+            default:
+                throw new IllegalStateException("The element of cache is not contained in any segment");
+        }
+    }
+
+    private void drainAdded(Lru.Node<T> node, Consumer<T> evict) {
+        sketch.increment(node.getKey().hashCode());
+
+        Lru.Node<T> windowEvict = window.push(node);
+        if (windowEvict == null) {
+            return;
+        }
+
+        Lru.Node<T> probationEvict = probation.nextEviction();
+        if (probationEvict == null) {
+            // Probation will be not evict any node, no-one is evicted.
+            probation.push(windowEvict);
+            return;
+        }
+
+        Lru.Node<T> evicted = sketch.frequency(windowEvict.getKey().hashCode()) >
+            sketch.frequency(probationEvict.getKey().hashCode()) ?
+            probation.push(windowEvict) : windowEvict;
+
+        if (evicted == null) {
+            // Impossible path, because probation eviction or window eviction should not be null.
+            return;
+        }
+
+        super.remove(evicted.getKey(), evicted);
+        evict.accept(evicted.getValue());
+    }
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/PrepareBoundedCache.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/PrepareBoundedCache.java
@@ -70,6 +70,11 @@ final class PrepareBoundedCache<T> extends HashMap<String, Lru.Node<T>> implemen
         return false;
     }
 
+    @Override
+    public String toString() {
+        return window.toString() + probation + protection;
+    }
+
     private void drainRead(Lru.Node<T> node) {
         sketch.increment(node.getKey().hashCode());
 

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/PrepareCache.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/PrepareCache.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import reactor.util.annotation.Nullable;
+
+import java.util.function.Consumer;
+
+/**
+ * An abstraction that considers cache of statement prepared results.
+ */
+public interface PrepareCache<T> {
+
+    /**
+     * Get the value of {@code key} in cache.
+     *
+     * @param key the key which want to get.
+     * @return the value of {@code key}, which is usually prepared statement ID.
+     */
+    @Nullable
+    T getIfPresent(String key);
+
+    /**
+     * Put the prepared result to the cache.
+     *
+     * @param key   the key of {@code value}, which is usually SQL statements.
+     * @param value the value of {@code key}, which is usually prepared statement ID.
+     * @param evict eviction value handler.
+     * @return {@code true} if {@code value} has been put succeed.
+     */
+    boolean putIfAbsent(String key, T value, Consumer<T> evict);
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/PrepareDisabledCache.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/PrepareDisabledCache.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import java.util.function.Consumer;
+
+/**
+ * A disabled {@link PrepareCache}.
+ */
+final class PrepareDisabledCache<T> implements PrepareCache<T> {
+
+    @Override
+    public T getIfPresent(String key) {
+        return null;
+    }
+
+    @Override
+    public boolean putIfAbsent(String key, T value, Consumer<T> evict) {
+        // Put always fails.
+        return false;
+    }
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/PrepareUnboundedCache.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/PrepareUnboundedCache.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * An unbounded implementation of {@link PrepareCache}.
+ */
+final class PrepareUnboundedCache<T> extends ConcurrentHashMap<String, T> implements PrepareCache<T> {
+
+    @Override
+    public T getIfPresent(String key) {
+        return super.get(key);
+    }
+
+    @Override
+    public boolean putIfAbsent(String key, T value, Consumer<T> evict) {
+        return super.putIfAbsent(key, value) == null;
+    }
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/QueryBoundedCache.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/QueryBoundedCache.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+
+/**
+ * A bounded implementation of {@link QueryCache} that supports high expected concurrency.
+ */
+final class QueryBoundedCache<T> extends ConcurrentHashMap<String, Lru.Node<T>> implements QueryCache<T> {
+
+    private static final int READ_BUFFER_SIZE = 16;
+
+    private static final int WRITE_BUFFER_SIZE = 32;
+
+    private final FreqSketch sketch;
+
+    private final RingBuffer<Lru.Node<T>> readBuffer;
+
+    private final RingBuffer<Lru.Node<T>> writeBuffer;
+
+    private final ReentrantLock lock;
+
+    private final Lru<T> window;
+
+    private final Lru<T> probation;
+
+    private final Lru<T> protection;
+
+    private final Function<String, T> mapping;
+
+    QueryBoundedCache(int capacity, Function<String, T> mapping) {
+        int windowSize = Math.max(1, capacity / 100);
+        int protectionSize = Math.max(1, (int) ((capacity - windowSize) * 0.8));
+        int probationSize = Math.max(1, capacity - protectionSize - windowSize);
+
+        this.sketch = new FreqSketch(windowSize + protectionSize + probationSize);
+        this.readBuffer = new RingBuffer<>(READ_BUFFER_SIZE, 3, this::drainRead);
+        this.writeBuffer = new RingBuffer<>(WRITE_BUFFER_SIZE, 50, this::drainAdded);
+        this.lock = new ReentrantLock();
+        this.window = new Lru<>(windowSize, Lru.WINDOW);
+        this.probation = new Lru<>(probationSize, Lru.PROBATION);
+        this.protection = new Lru<>(protectionSize, Lru.PROTECTION);
+        this.mapping = mapping;
+    }
+
+    @Override
+    public T get(String key) {
+        // An optimistic fast path to avoid unnecessary locking.
+        Lru.Node<T> node = super.get(key);
+        if (node != null) {
+            afterRead(node);
+            return node.getValue();
+        }
+
+        boolean[] present = new boolean[]{true};
+
+        // It always return current (existing or computed) value.
+        node = super.computeIfAbsent(key, (k) -> {
+            present[0] = false;
+            return new Lru.Node<>(k, mapping.apply(k));
+        });
+
+        if (present[0]) {
+            afterRead(node);
+        } else {
+            afterAdded(node);
+        }
+
+        return node.getValue();
+    }
+
+    private void afterRead(Lru.Node<T> node) {
+        boolean isFailed = !readBuffer.offer(node);
+
+        /*
+         * Inspired by Caffeine:
+         *
+         * When a cache hit occurs then processing the node is a policy hint, e.g. to LRU reorder.
+         * This is best-effort and the work could be dropped, e.g. if the buffer is full (or CAS fails).
+         * This favors concurrent throughput and likely the same popular entries are being accessed.
+         * If so, the eviction policy is already going to favor them so being strict won't change
+         * the hit rate substantially. Being lossy can improve the system throughput, so generally a
+         * favorable tradeoff.
+         *
+         * So there is using tryLock instead of lock for performance, even offer fails.
+         */
+        if (lock.tryLock()) {
+            try {
+                readBuffer.drainAll();
+                if (isFailed) {
+                    drainRead(node);
+                }
+                writeBuffer.drainAll();
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    private void afterAdded(Lru.Node<T> node) {
+        /*
+         * When a cache miss occurs then the entry must be added to the LRU and maybe
+         * an eviction occurs. This must occur, so it has the work has to be processed
+         * and not dropped.
+         *
+         * So there is using lock when offer fails.
+         */
+        if (writeBuffer.offer(node)) {
+            if (lock.tryLock()) {
+                try {
+                    readBuffer.drainAll();
+                    writeBuffer.drainAll();
+                } finally {
+                    lock.unlock();
+                }
+            }
+        } else {
+            lock.lock();
+            try {
+                readBuffer.drainAll();
+                writeBuffer.drainAll();
+                drainAdded(node);
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    private void drainAdded(Lru.Node<T> node) {
+        sketch.increment(node.getKey().hashCode());
+
+        Lru.Node<T> windowEvict = window.push(node);
+        if (windowEvict == null) {
+            return;
+        }
+
+        Lru.Node<T> probationEvict = probation.nextEviction();
+        if (probationEvict == null) {
+            // Probation will be not evict any node, no-one is evicted.
+            probation.push(windowEvict);
+            return;
+        }
+
+        Lru.Node<T> evicted = sketch.frequency(windowEvict.getKey().hashCode()) >
+            sketch.frequency(probationEvict.getKey().hashCode()) ?
+            probation.push(windowEvict) : windowEvict;
+
+        if (evicted == null) {
+            // Impossible path, because probation eviction or window eviction should not be null.
+            return;
+        }
+
+        super.remove(evicted.getKey(), evicted);
+    }
+
+    private void drainRead(Lru.Node<T> node) {
+        sketch.increment(node.getKey().hashCode());
+
+        switch (node.getLru()) {
+            case Lru.WINDOW:
+                window.refresh(node);
+                break;
+            case Lru.PROBATION:
+                probation.remove(node);
+                Lru.Node<T> evicted = protection.push(node);
+
+                if (evicted != null) {
+                    // This element must be protected.
+                    // Result should be null because probation has removed one element.
+                    probation.push(evicted);
+                }
+                break;
+            case Lru.PROTECTION:
+                protection.refresh(node);
+                break;
+            // default: break; // It was evicted by last wrote, or was holden in write buffer.
+        }
+    }
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/QueryCache.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/QueryCache.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+/**
+ * An abstraction that considers cache of query parsed results.
+ */
+public interface QueryCache<T> {
+
+    T get(String key);
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/QueryDisabledCache.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/QueryDisabledCache.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import java.util.function.Function;
+
+/**
+ * A disabled {@link QueryCache}.
+ */
+final class QueryDisabledCache<T> implements QueryCache<T> {
+
+    private final Function<String, T> mapping;
+
+    QueryDisabledCache(Function<String, T> mapping) {
+        this.mapping = mapping;
+    }
+
+    @Override
+    public T get(String key) {
+        return mapping.apply(key);
+    }
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/QueryUnboundedCache.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/QueryUnboundedCache.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * An unbounded implementation of {@link QueryCache}.
+ */
+final class QueryUnboundedCache<T> extends ConcurrentHashMap<String, T> implements QueryCache<T> {
+
+    private final Function<String, T> mapping;
+
+    QueryUnboundedCache(Function<String, T> mapping) {
+        this.mapping = mapping;
+    }
+
+    @Override
+    public T get(String key) {
+        // An optimistic fast path to avoid unnecessary locking.
+        T value = super.get(key);
+        return value == null ? super.computeIfAbsent(key, mapping) : value;
+    }
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/RingBuffer.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/RingBuffer.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Consumer;
+
+import static dev.miku.r2dbc.mysql.util.AssertUtils.require;
+
+/**
+ * Avoid false sharding. Assume the cache line is 128 bytes.
+ */
+abstract class LeftPad {
+
+    long p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14;
+}
+
+/**
+ * A non-blocking bounded ring buffer.
+ */
+final class RingBuffer<T> extends LeftPad {
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicIntegerFieldUpdater<RingBuffer> HEAD =
+        AtomicIntegerFieldUpdater.newUpdater(RingBuffer.class, "head");
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicIntegerFieldUpdater<RingBuffer> TAIL =
+        AtomicIntegerFieldUpdater.newUpdater(RingBuffer.class, "tail");
+
+    /**
+     * The index scale of {@link Object} arrays. Don't use {@code Unsafe} because it may be unstable.
+     */
+    private static final int SCALE = 4;
+
+    private static final int SHIFT = Integer.numberOfTrailingZeros(128) - Integer.numberOfTrailingZeros(SCALE);
+
+    private static final int PADDING = (1 << SHIFT) - 1;
+
+    private volatile int head; // p15 1st part
+
+    int p15; // p15 2nd part
+
+    long p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30;
+
+    private volatile int tail; // p31 1st part
+
+    int p31; // p31 2nd part
+
+    long p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45, p46;
+
+    private final AtomicReferenceArray<T> buffer;
+
+    private final int maxSize;
+
+    private final int mask;
+
+    private final int retry;
+
+    private final Consumer<T> consumer;
+
+    RingBuffer(int capacity, int retry, Consumer<T> consumer) {
+        require(capacity > 0 && capacity <= Caches.MAX_CAPACITY, "capacity must be a valid integer");
+
+        int maxSize = Caches.ceilingPowerOfTwo(capacity);
+
+        this.maxSize = maxSize;
+        this.mask = maxSize - 1;
+        this.buffer = new AtomicReferenceArray<>((maxSize << SHIFT) + PADDING);
+        this.retry = retry;
+        this.consumer = consumer;
+    }
+
+    /**
+     * Should NEVER use &lt; or &gt; to compare {@link #head} and {@link #tail} directly,
+     * because they may overflow. Calculate {@code tail - head} to check current buffer size.
+     *
+     * @param value the element to be offered.
+     * @return {@code true} if succeed, otherwise failed.
+     */
+    boolean offer(T value) {
+        for (int i = 0; i < retry; ++i) {
+            int tail = this.tail;
+            int size = tail - this.head;
+
+            if (size >= this.maxSize) {
+                return false;
+            }
+
+            /*
+             * Increment first, set value second. Pre-calculate offset for minimize
+             * the process between tail increment and value set. Maybe use `lazySet`
+             * for value set? Currently, consider using set to be immediately visible
+             * to other threads.
+             */
+            int offset = getOffset(tail);
+            if (TAIL.compareAndSet(this, tail, tail + 1)) {
+                this.buffer.set(offset, value);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Should NEVER use &lt; or &gt; to compare {@link #head} and {@link #tail} directly,
+     * because they may overflow. Calculate {@code tail - head} to check current buffer size.
+     */
+    void drainAll() {
+        // Consume to current tail, do NOT extract tail in each loop to avoid inf loop.
+        // And this can avoid to getting unclear value in loop.
+        // Must read head first to avoid race.
+        int head = this.head;
+        int tail = this.tail;
+        int size = tail - head;
+
+        if (size < 0 || size > this.maxSize) {
+            throw new IllegalStateException("Impossible size between " + head + " and " + tail);
+        } else if (size == 0) {
+            return;
+        }
+
+        // Counting null value to avoid inf loop.
+        int nullCount = 0, maxNullCount = Math.min(size << 2, 128);
+
+        // The size may be negative when other thread consuming and another one offering this buffer.
+        for (; size > 0; size = tail - (head = this.head)) {
+            int offset = getOffset(head);
+            T value = buffer.get(offset);
+
+            if (value == null) {
+                // Tail was increased but value hasn't set, or has already been consumed by other thread.
+                if (nullCount++ < maxNullCount) {
+                    // Try again.
+                    continue;
+                } else {
+                    // An intense race condition, quit.
+                    break;
+                }
+            }
+
+            if (HEAD.compareAndSet(this, head, head + 1)) {
+                // Element may be offered immediately when the head increment, then new element
+                // will be wrote to last location. So using CAS here to avoid rewrite the new
+                // element. And we don't care if CAS succeeds or fails.
+                buffer.compareAndSet(offset, value, null);
+                consumer.accept(value);
+            }
+        }
+    }
+
+    long keeping(int v) {
+        return p0 = p1 = p2 = p3 = p4 = p5 = p6 = p8 = p9 = p10 = p11 = p12 = p13 = p14 =
+            p16 = p17 = p18 = p19 = p20 = p21 = p22 = p23 = p24 = p25 = p26 = p27 = p28 = p29 = p30 =
+                p32 = p33 = p34 = p35 = p36 = p37 = p38 = p39 = p40 = p41 = p42 = p43 = p44 = p45 = p46 =
+                    p7 = p15 = p31 = v;
+    }
+
+    private int getOffset(int index) {
+        return ((index & mask) << SHIFT) + PADDING;
+    }
+}

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/RingBuffer.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/RingBuffer.java
@@ -52,6 +52,8 @@ final class RingBuffer<T> extends LeftPad {
 
     private static final int PADDING = (1 << SHIFT) - 1;
 
+    private static final int MAX_SIZE = 256; // 256 * 128 + 127 = 32768 + 127, should not too large
+
     private volatile int head; // p15 1st part
 
     int p15; // p15 2nd part
@@ -75,7 +77,7 @@ final class RingBuffer<T> extends LeftPad {
     private final Consumer<T> consumer;
 
     RingBuffer(int capacity, int retry, Consumer<T> consumer) {
-        require(capacity > 0 && capacity <= Caches.MAX_CAPACITY, "capacity must be a valid integer");
+        require(capacity > 0 && capacity <= MAX_SIZE, "capacity must between 1 and 256");
 
         int maxSize = Caches.ceilingPowerOfTwo(capacity);
 

--- a/src/main/java/dev/miku/r2dbc/mysql/cache/package-info.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/cache/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Cache supports for query parse and statement preparation.
+ */
+
+@NonNullApi
+package dev.miku.r2dbc.mysql.cache;
+
+import reactor.util.annotation.NonNullApi;

--- a/src/main/java/dev/miku/r2dbc/mysql/client/ReactorNettyClient.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/client/ReactorNettyClient.java
@@ -326,15 +326,17 @@ final class ReactorNettyClient implements Client {
 
         @Override
         public void next(ServerMessage message) {
-            if (INFO_ENABLED) {
-                if (message instanceof WarningMessage) {
-                    int warnings = ((WarningMessage) message).getWarnings();
-                    if (warnings != 0) {
-                        logger.info("Response: {}, reports {} warning(s)", message, warnings);
+            if (message instanceof WarningMessage) {
+                int warnings = ((WarningMessage) message).getWarnings();
+                if (warnings == 0) {
+                    if (DEBUG_ENABLED) {
+                        logger.debug("Response: {}", message);
                     }
-                } else if (DEBUG_ENABLED) {
-                    logger.debug("Response: {}", message);
+                } else if (INFO_ENABLED) {
+                    logger.info("Response: {}, reports {} warning(s)", message, warnings);
                 }
+            } else if (DEBUG_ENABLED) {
+                logger.debug("Response: {}", message);
             }
 
             ReactorNettyClient.this.responseProcessor.onNext(message);

--- a/src/main/java/dev/miku/r2dbc/mysql/message/client/PreparedCloseMessage.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/message/client/PreparedCloseMessage.java
@@ -55,7 +55,6 @@ public final class PreparedCloseMessage extends FixedSizeClientMessage implement
         PreparedCloseMessage that = (PreparedCloseMessage) o;
 
         return statementId == that.statementId;
-
     }
 
     @Override
@@ -65,6 +64,6 @@ public final class PreparedCloseMessage extends FixedSizeClientMessage implement
 
     @Override
     public String toString() {
-        return String.format("PreparedCloseMessage{statementId=%d}", statementId);
+        return "PreparedCloseMessage{statementId=" + statementId + '}';
     }
 }

--- a/src/main/java/dev/miku/r2dbc/mysql/message/client/PreparedResetMessage.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/message/client/PreparedResetMessage.java
@@ -19,17 +19,17 @@ package dev.miku.r2dbc.mysql.message.client;
 import io.netty.buffer.ByteBuf;
 
 /**
- * A message that close the prepared statement specified by id.
+ * A message that reset the prepared statement specified by id.
  */
-public final class PreparedCloseMessage extends FixedSizeClientMessage implements SendOnlyMessage {
+public final class PreparedResetMessage extends FixedSizeClientMessage {
 
     private static final int SIZE = Byte.BYTES + Integer.BYTES;
 
-    private static final byte CLOSE_FLAG = 0x19;
+    private static final byte RESET_FLAG = 0x1A;
 
     private final int statementId;
 
-    public PreparedCloseMessage(int statementId) {
+    public PreparedResetMessage(int statementId) {
         this.statementId = statementId;
     }
 
@@ -40,31 +40,6 @@ public final class PreparedCloseMessage extends FixedSizeClientMessage implement
 
     @Override
     protected void writeTo(ByteBuf buf) {
-        buf.writeByte(CLOSE_FLAG).writeIntLE(statementId);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof PreparedCloseMessage)) {
-            return false;
-        }
-
-        PreparedCloseMessage that = (PreparedCloseMessage) o;
-
-        return statementId == that.statementId;
-
-    }
-
-    @Override
-    public int hashCode() {
-        return statementId;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("PreparedCloseMessage{statementId=%d}", statementId);
+        buf.writeByte(RESET_FLAG).writeIntLE(statementId);
     }
 }

--- a/src/main/java/dev/miku/r2dbc/mysql/message/client/PreparedResetMessage.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/message/client/PreparedResetMessage.java
@@ -42,4 +42,28 @@ public final class PreparedResetMessage extends FixedSizeClientMessage {
     protected void writeTo(ByteBuf buf) {
         buf.writeByte(RESET_FLAG).writeIntLE(statementId);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PreparedResetMessage that = (PreparedResetMessage) o;
+
+        return statementId == that.statementId;
+    }
+
+    @Override
+    public int hashCode() {
+        return statementId;
+    }
+
+    @Override
+    public String toString() {
+        return "PreparedResetMessage{statementId=" + statementId + '}';
+    }
 }

--- a/src/main/java/dev/miku/r2dbc/mysql/message/client/TextQueryMessage.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/message/client/TextQueryMessage.java
@@ -24,7 +24,6 @@ import reactor.core.publisher.Mono;
 
 import java.nio.charset.Charset;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static dev.miku.r2dbc.mysql.util.AssertUtils.require;
 import static dev.miku.r2dbc.mysql.util.AssertUtils.requireNonNull;
@@ -40,18 +39,14 @@ public final class TextQueryMessage extends LargeClientMessage implements Exchan
 
     private final Parameter[] values;
 
-    private final Consumer<String> sqlProceed;
-
-    public TextQueryMessage(List<String> sqlParts, Parameter[] values, Consumer<String> sqlProceed) {
+    public TextQueryMessage(List<String> sqlParts, Parameter[] values) {
         requireNonNull(sqlParts, "sql parts must not be null");
         requireNonNull(values, "values must not be null");
-        requireNonNull(sqlProceed, "sqlProceed must not be null");
         require(sqlParts.size() - 1 == values.length, "sql parts size must not be parameters size + 1");
 
 
         this.sqlParts = sqlParts;
         this.values = values;
-        this.sqlProceed = sqlProceed;
     }
 
     @Override
@@ -64,8 +59,6 @@ public final class TextQueryMessage extends LargeClientMessage implements Exchan
         try {
             Charset charset = context.getClientCollation().getCharset();
             return ParamWriter.publish(sqlParts, values).map(sql -> {
-                sqlProceed.accept(sql);
-
                 ByteBuf buf = allocator.buffer(sql.length(), Integer.MAX_VALUE);
 
                 buf.writeByte(SimpleQueryMessage.QUERY_FLAG)

--- a/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -198,6 +198,8 @@ class MySqlConnectionConfigurationTest {
             .serverZoneId(ZoneId.systemDefault())
             .zeroDateOption(ZeroDateOption.USE_NULL)
             .sslHostnameVerifier((host, s) -> true)
+            .queryCacheSize(128)
+            .prepareCacheSize(0)
             .autodetectExtensions(false)
             .build();
     }

--- a/src/test/java/dev/miku/r2dbc/mysql/PrepareParametrizedStatementTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/PrepareParametrizedStatementTest.java
@@ -16,6 +16,7 @@
 
 package dev.miku.r2dbc.mysql;
 
+import dev.miku.r2dbc.mysql.cache.Caches;
 import dev.miku.r2dbc.mysql.client.Client;
 import dev.miku.r2dbc.mysql.codec.Codecs;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -48,7 +49,8 @@ class PrepareParametrizedStatementTest implements StatementTestSupport<PreparePa
 
     @Override
     public PrepareParametrizedStatement makeInstance(String parametrizedSql, String simpleSql) {
-        return new PrepareParametrizedStatement(client, codecs, context, (PrepareQuery) Query.parse(parametrizedSql, true));
+        return new PrepareParametrizedStatement(client, codecs, context,
+            (PrepareQuery) Query.parse(parametrizedSql, true), Caches.createPrepareCache(0));
     }
 
     @Override

--- a/src/test/java/dev/miku/r2dbc/mysql/PrepareSimpleStatementTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/PrepareSimpleStatementTest.java
@@ -16,6 +16,7 @@
 
 package dev.miku.r2dbc.mysql;
 
+import dev.miku.r2dbc.mysql.cache.Caches;
 import dev.miku.r2dbc.mysql.client.Client;
 import dev.miku.r2dbc.mysql.codec.Codecs;
 
@@ -62,7 +63,7 @@ class PrepareSimpleStatementTest implements StatementTestSupport<PrepareSimpleSt
 
     @Override
     public PrepareSimpleStatement makeInstance(String parametrizedSql, String simpleSql) {
-        return new PrepareSimpleStatement(client, codecs, context, simpleSql);
+        return new PrepareSimpleStatement(client, codecs, context, simpleSql, Caches.createPrepareCache(0));
     }
 
     @Override

--- a/src/test/java/dev/miku/r2dbc/mysql/cache/FreqSketchTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/cache/FreqSketchTest.java
@@ -44,7 +44,6 @@ class FreqSketchTest {
         typeAssert.isThrownBy(() -> new FreqSketch(-1));
         typeAssert.isThrownBy(() -> new FreqSketch(Integer.MIN_VALUE));
         typeAssert.isThrownBy(() -> new FreqSketch(Integer.MIN_VALUE >> 1));
-        typeAssert.isThrownBy(() -> new FreqSketch(Integer.MAX_VALUE));
     }
 
     @Test

--- a/src/test/java/dev/miku/r2dbc/mysql/cache/FreqSketchTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/cache/FreqSketchTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import org.assertj.core.api.ThrowableTypeAssert;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Unit tests for {@link FreqSketch}.
+ */
+class FreqSketchTest {
+
+    private final int hashCode = ThreadLocalRandom.current().nextInt();
+
+    @Test
+    void badConstruct() {
+        ThrowableTypeAssert<IllegalArgumentException> typeAssert = assertThatIllegalArgumentException();
+
+        typeAssert.isThrownBy(() -> new FreqSketch(0));
+        typeAssert.isThrownBy(() -> new FreqSketch(-1));
+        typeAssert.isThrownBy(() -> new FreqSketch(Integer.MIN_VALUE));
+        typeAssert.isThrownBy(() -> new FreqSketch(Integer.MIN_VALUE >> 1));
+        typeAssert.isThrownBy(() -> new FreqSketch(Integer.MAX_VALUE));
+    }
+
+    @Test
+    void incrementOnce() {
+        FreqSketch sketch = new FreqSketch(1);
+
+        sketch.increment(hashCode);
+        assertThat(sketch.frequency(hashCode)).isEqualTo(1);
+    }
+
+    @Test
+    void incrementMax() {
+        FreqSketch sketch = new FreqSketch(256);
+
+        for (int i = 0; i < 20; i++) {
+            sketch.increment(hashCode);
+        }
+
+        assertThat(sketch.frequency(hashCode)).isEqualTo(15);
+    }
+
+    @Test
+    void incrementDistinct() {
+        FreqSketch sketch = new FreqSketch(256);
+
+        sketch.increment(hashCode);
+        sketch.increment(hashCode + 1);
+        assertThat(sketch.frequency(hashCode)).isEqualTo(1);
+        assertThat(sketch.frequency(hashCode + 1)).isEqualTo(1);
+        assertThat(sketch.frequency(hashCode + 2)).isEqualTo(0);
+    }
+
+    @Test
+    void indexOfAroundZero() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method indexOf = FreqSketch.class.getDeclaredMethod("indexOf", int.class, int.class);
+        FreqSketch sketch = new FreqSketch(256);
+        Set<Integer> indexes = new HashSet<>(16);
+        int[] hashes = { -1, 0, 1 };
+
+        indexOf.setAccessible(true);
+
+        for (int hash : hashes) {
+            for (int i = 0; i < 4; i++) {
+                indexes.add((Integer) indexOf.invoke(sketch, hash, i));
+            }
+        }
+
+        assertThat(indexes).hasSize(hashes.length << 2);
+    }
+
+    @Test
+    void reset() throws NoSuchFieldException, IllegalAccessException {
+        boolean reset = false;
+        Field table = FreqSketch.class.getDeclaredField("table");
+        Field size = FreqSketch.class.getDeclaredField("size");
+        Field sampling = FreqSketch.class.getDeclaredField("sampling");
+        FreqSketch sketch = new FreqSketch(64);
+
+        table.setAccessible(true);
+        size.setAccessible(true);
+        sampling.setAccessible(true);
+
+        int length = ((long[]) table.get(sketch)).length * 20;
+
+        for (int i = 1; i < length; i++) {
+            sketch.increment(i);
+            if (size.getInt(sketch) != i) {
+                reset = true;
+                break;
+            }
+        }
+        assertThat(reset).isTrue();
+        assertThat(size.getInt(sketch)).isLessThanOrEqualTo(sampling.getInt(sketch) >>> 1);
+    }
+
+    @Test
+    public void heavyHitters() {
+        FreqSketch sketch = new FreqSketch(256);
+        for (int i = 100; i < 100_000; i++) {
+            sketch.increment(Double.hashCode(i));
+        }
+        for (int i = 0; i < 10; i += 2) {
+            for (int j = 0; j < i; j++) {
+                sketch.increment(Double.hashCode(i));
+            }
+        }
+
+        // A perfect popularity count yields an array [0, 0, 2, 0, 4, 0, 6, 0, 8, 0]
+        int[] popularity = new int[10];
+        for (int i = 0; i < 10; i++) {
+            popularity[i] = sketch.frequency(Double.hashCode(i));
+        }
+        for (int i = 0; i < popularity.length; i++) {
+            if ((i == 0) || (i == 1) || (i == 3) || (i == 5) || (i == 7) || (i == 9)) {
+                assertThat(popularity[i]).isLessThanOrEqualTo(popularity[2]);
+            } else if (i == 2) {
+                assertThat(popularity[2]).isLessThanOrEqualTo(popularity[4]);
+            } else if (i == 4) {
+                assertThat(popularity[4]).isLessThanOrEqualTo(popularity[6]);
+            } else if (i == 6) {
+                assertThat(popularity[6]).isLessThanOrEqualTo(popularity[8]);
+            }
+        }
+    }
+}

--- a/src/test/java/dev/miku/r2dbc/mysql/cache/LruTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/cache/LruTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link Lru}.
+ */
+class LruTest {
+
+    private static final int LRU_SIZE = 3;
+
+    @Test
+    void refresh() {
+        Lru<Integer> list = mockLru();
+        Lru.Node<Integer> one = new Lru.Node<>("1", 1);
+
+        assertThat(list.push(one)).isNull();
+        assertThat(list.toString()).isEqualTo("[1]");
+        list.refresh(one);
+        assertThat(list.toString()).isEqualTo("[1]");
+
+        Lru.Node<Integer> two = new Lru.Node<>("2", 2);
+
+        assertThat(list.push(two)).isNull();
+        assertThat(list.toString()).isEqualTo("[2, 1]");
+        list.refresh(one);
+        assertThat(list.toString()).isEqualTo("[1, 2]");
+        list.refresh(two);
+        assertThat(list.toString()).isEqualTo("[2, 1]");
+
+        Lru.Node<Integer> three = new Lru.Node<>("3", 3);
+
+        assertThat(list.push(three)).isNull();
+        assertThat(list.toString()).isEqualTo("[3, 2, 1]");
+        list.refresh(two);
+        assertThat(list.toString()).isEqualTo("[2, 3, 1]");
+        list.refresh(one);
+        assertThat(list.toString()).isEqualTo("[1, 2, 3]");
+        list.refresh(two);
+        assertThat(list.toString()).isEqualTo("[2, 1, 3]");
+        list.refresh(three);
+        assertThat(list.toString()).isEqualTo("[3, 2, 1]");
+        list.refresh(three);
+        assertThat(list.toString()).isEqualTo("[3, 2, 1]");
+
+        assertThat(list.push(new Lru.Node<>("4", 4)))
+            .isNotNull()
+            .extracting(Lru.Node::getValue)
+            .isEqualTo(1);
+
+        assertThat(list.toString()).isEqualTo("[4, 3, 2]");
+    }
+
+    @Test
+    void push() {
+        Lru<Integer> list = mockLru();
+
+        assertThat(list.toString()).isEqualTo("[]");
+        assertThat(list.push(new Lru.Node<>("1", 1))).isNull();
+        assertThat(list.toString()).isEqualTo("[1]");
+        assertThat(list.push(new Lru.Node<>("2", 2))).isNull();
+        assertThat(list.toString()).isEqualTo("[2, 1]");
+        assertThat(list.push(new Lru.Node<>("3", 3))).isNull();
+        assertThat(list.toString()).isEqualTo("[3, 2, 1]");
+
+        assertThat(list.push(new Lru.Node<>("4", 4)))
+            .isNotNull()
+            .extracting(Lru.Node::getValue)
+            .isEqualTo(1);
+
+        assertThat(list.toString()).isEqualTo("[4, 3, 2]");
+    }
+
+    private static <T> Lru<T> mockLru() {
+        return new Lru<>(LRU_SIZE, 1);
+    }
+}

--- a/src/test/java/dev/miku/r2dbc/mysql/cache/PrepareBoundedCacheTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/cache/PrepareBoundedCacheTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.miku.r2dbc.mysql.cache;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PrepareBoundedCache}.
+ */
+class PrepareBoundedCacheTest {
+
+    private static final int DEFAULT_CAPACITY = 256;
+
+    @Test
+    void putIfAbsent() {
+        PrepareBoundedCache<Integer> cache = mock();
+
+        assertThat(cache.toString()).isEqualTo("[][][]");
+        assertThat(cache.putIfAbsent("SELECT 1", 1, ExceptionConsumer.INSTANCE)).isTrue();
+        assertThat(cache.toString()).isEqualTo("[1][][]");
+        assertThat(cache.putIfAbsent("SELECT 1", 2, ExceptionConsumer.INSTANCE)).isFalse();
+        assertThat(cache.toString()).isEqualTo("[1][][]");
+        assertThat(cache.getIfPresent("SELECT 1")).isEqualTo(1);
+    }
+
+    @Test
+    void getIfPresent() {
+        PrepareBoundedCache<Integer> cache = mock();
+
+        assertThat(cache.toString()).isEqualTo("[][][]");
+        assertThat(cache.getIfPresent("SELECT 1")).isNull();
+        assertThat(cache.putIfAbsent("SELECT 1", 1, ExceptionConsumer.INSTANCE)).isTrue();
+        assertThat(cache.toString()).isEqualTo("[1][][]");
+        assertThat(cache.getIfPresent("SELECT 1")).isEqualTo(1);
+    }
+
+    private static PrepareBoundedCache<Integer> mock() {
+        return new PrepareBoundedCache<>(DEFAULT_CAPACITY);
+    }
+
+    private static final class ExceptionConsumer implements Consumer<Integer> {
+
+        private static final ExceptionConsumer INSTANCE = new ExceptionConsumer();
+
+        @Override
+        public void accept(Integer value) {
+            throw new RuntimeException("Unexpected value: " + value);
+        }
+    }
+}


### PR DESCRIPTION
See also #43 and #44 .

Previously, the integration tests was poor which means it was hard to foresee the problems after the cache was added. And, the `Client` was not support batch requests in one `exchange`, the cached status of prepared results is prone to problems.

These problems are obviously improved now, so this feature is re-proposed.