### PR TITLE
Adding support for MySQL Clear Text Authentication

### DIFF
--- a/src/main/java/dev/miku/r2dbc/mysql/authentication/MySqlAuthProvider.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/authentication/MySqlAuthProvider.java
@@ -61,6 +61,11 @@ public interface MySqlAuthProvider {
     String NO_AUTH_PROVIDER = "";
 
     /**
+     * Supporting MySQL Clear Text Authentication
+     */
+    String MYSQL_CLEAR_PASSWORD = "mysql_clear_password";
+
+    /**
      * Get the built-in authentication plugin provider through the specified {@code type}.
      *
      * @param type the type name of a authentication plugin provider
@@ -81,6 +86,8 @@ public interface MySqlAuthProvider {
                 return OldAuthProvider.INSTANCE;
             case NO_AUTH_PROVIDER:
                 return NoAuthProvider.INSTANCE;
+            case MYSQL_CLEAR_PASSWORD:
+                return MySqlClearAuthProvider.INSTANCE;
         }
 
         throw new R2dbcPermissionDeniedException("Authentication plugin '" + type + "' not found");

--- a/src/main/java/dev/miku/r2dbc/mysql/authentication/MySqlClearAuthProvider.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/authentication/MySqlClearAuthProvider.java
@@ -1,0 +1,42 @@
+package dev.miku.r2dbc.mysql.authentication;
+
+import static dev.miku.r2dbc.mysql.util.AssertUtils.requireNonNull;
+
+import java.nio.CharBuffer;
+
+import static dev.miku.r2dbc.mysql.constant.Envelopes.TERMINAL;
+import dev.miku.r2dbc.mysql.collation.CharCollation;
+
+/**
+ * An implementation of {@link MySqlAuthProvider} for type "mysql_clear_password".
+ */
+public class MySqlClearAuthProvider implements MySqlAuthProvider {
+
+	static final MySqlClearAuthProvider INSTANCE = new MySqlClearAuthProvider();
+	
+	@Override
+	public String getType() {
+		return MYSQL_CLEAR_PASSWORD;
+	}
+
+	@Override
+	public boolean isSslNecessary() {
+		return true;
+	}
+
+	@Override
+	public byte[] authentication(CharSequence password, byte[] salt, CharCollation collation) {
+		if (password == null || password.length() <= 0) {
+            return new byte[] { TERMINAL };
+        }
+		requireNonNull(collation, "collation must not be null when password exists");
+
+		return AuthUtils.encodeTerminal(CharBuffer.wrap(password), collation.getCharset());
+	}
+
+	@Override
+	public MySqlAuthProvider next() {
+		return this;
+	}
+
+}


### PR DESCRIPTION
I had a need to use AWS RDS Proxy within a Spring Boot application that utilizes r2dbc-mysql.  Unfortunately, I was getting "Authentication plugin 'mysql_clear_password' not found.  To fix this, I needed to add this authentication provider.

Here is an example using AWS SDK for Java v2

```
@Configuration
@EnableTransactionManagement
@EnableR2dbcRepositories
@EntityScan(basePackages = {"com.company.admin.entity"})
public class DatabaseConfiguration extends AbstractR2dbcConfiguration {
		
	@Autowired
	private ParamConfiguration paramConfiguration;
	
	@Bean
	public ReactiveTransactionManager transactionManager(ConnectionFactory connectionFactory) {
	  return new R2dbcTransactionManager(connectionFactory);
	}
		
	@Bean
	@Override
	public ConnectionFactory connectionFactory() {		
		MySqlConnectionConfiguration configuration = 
				MySqlConnectionConfiguration
					.builder()
						.host(paramConfiguration.getDbAdminProxy())
						.database(paramConfiguration.getDbName())
						.user(paramConfiguration.getDbUser())
						.sslMode(SslMode.REQUIRED)
						
						.password(
								generateAuthToken(
										Region.of(paramConfiguration.getAwsRegion()), 
										paramConfiguration.getDbAdminProxy(), 
										paramConfiguration.getDbPort(), 
										paramConfiguration.getDbUser()))
					.build();
		
		ConnectionFactory connectionFactory = MySqlConnectionFactory.from(configuration);
		return  connectionFactory;
	}
	
	
	static String generateAuthToken(Region region, String hostName, String port, String username) {
		GenerateAuthenticationTokenRequest tokenRequest = GenerateAuthenticationTokenRequest.builder()
				.hostname(hostName)
				.port(Integer.parseInt(port))
				.username(username)
				.build();				
	
		RdsUtilities utilities = RdsUtilities.builder()
				  .credentialsProvider(DefaultCredentialsProvider.create())
				  .region(region)
				  .build();
		return utilities.generateAuthenticationToken(tokenRequest);		
	}
	
}
``` 

