### PR TITLE
TCP socket timeout for a configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
     .option(PASSWORD, "database-password-in-here") // optional, default null, null means has no password
     .option(DATABASE, "r2dbc") // optional, default null, null means not specifying the database
     .option(CONNECT_TIMEOUT, Duration.ofSeconds(3)) // optional, default null, null means no timeout
+    .option(Option.valueOf("socketTimeout"), Duration.ofSeconds(4)) // optional, default null, null means no timeout
     .option(SSL, true) // optional, default sslMode is "preferred", it will be ignore if sslMode is set
     .option(Option.valueOf("sslMode"), "verify_identity") // optional, default "preferred"
     .option(Option.valueOf("sslCa"), "/path/to/mysql/ca.pem") // required when sslMode is verify_ca or verify_identity, default null, null means has no server CA cert
@@ -175,6 +176,7 @@ MySqlConnectionConfiguration configuration = MySqlConnectionConfiguration.builde
     .database("r2dbc") // optional, default null, null means not specifying the database
     .serverZoneId(ZoneId.of("Continent/City")) // optional, default null, null means query server time zone when connection init
     .connectTimeout(Duration.ofSeconds(3)) // optional, default null, null means no timeout
+    .socketTimeout(Duration.ofSeconds(4)) // optional, default null, null means no timeout
     .sslMode(SslMode.VERIFY_IDENTITY) // optional, default SslMode.PREFERRED
     .sslCa("/path/to/mysql/ca.pem") // required when sslMode is VERIFY_CA or VERIFY_IDENTITY, default null, null means has no server CA cert
     .sslCert("/path/to/mysql/client-cert.pem") // optional, default has no client SSL certificate
@@ -221,6 +223,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | password | Any printable string | Optional, default no password | The password of the MySQL database user |
 | database | A valid MySQL database name | Optional, default does not initialize database | Database used by the MySQL connection |
 | connectTimeout | A `Duration` which must be positive duration | Optional, default has no timeout | TCP connect timeout |
+| socketTimeout | A `Duration` which must be positive duration | Optional, default has no timeout | TCP socket timeout |
 | serverZoneId | An id of `ZoneId` | Optional, default query time zone when connection init | Server time zone id |
 | tcpKeepAlive | `true` or `false` | Optional, default disabled | Controls TCP KeepAlive |
 | tcpNoDelay | `true` or `false` | Optional, default disabled | Controls TCP NoDelay |

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -71,6 +71,9 @@ public final class MySqlConnectionConfiguration {
     private final Duration connectTimeout;
 
     @Nullable
+    private final Duration socketTimeout;
+
+    @Nullable
     private final ZoneId serverZoneId;
 
     private final ZeroDateOption zeroDateOption;
@@ -93,8 +96,8 @@ public final class MySqlConnectionConfiguration {
 
     private MySqlConnectionConfiguration(boolean isHost, String domain, int port, MySqlSslConfiguration ssl,
         boolean tcpKeepAlive, boolean tcpNoDelay, @Nullable Duration connectTimeout,
-        ZeroDateOption zeroDateOption, @Nullable ZoneId serverZoneId, String user,
-        @Nullable CharSequence password, @Nullable String database,
+        @Nullable Duration socketTimeout, ZeroDateOption zeroDateOption, @Nullable ZoneId serverZoneId,
+        String user, @Nullable CharSequence password, @Nullable String database,
         @Nullable Predicate<String> preferPrepareStatement, int queryCacheSize, int prepareCacheSize,
         Extensions extensions) {
         this.isHost = isHost;
@@ -103,6 +106,7 @@ public final class MySqlConnectionConfiguration {
         this.tcpKeepAlive = tcpKeepAlive;
         this.tcpNoDelay = tcpNoDelay;
         this.connectTimeout = connectTimeout;
+        this.socketTimeout = socketTimeout;
         this.ssl = ssl;
         this.serverZoneId = serverZoneId;
         this.zeroDateOption = requireNonNull(zeroDateOption, "zeroDateOption must not be null");
@@ -139,6 +143,11 @@ public final class MySqlConnectionConfiguration {
     @Nullable
     Duration getConnectTimeout() {
         return connectTimeout;
+    }
+
+    @Nullable
+    Duration getSocketTimeout() {
+        return socketTimeout;
     }
 
     MySqlSslConfiguration getSsl() {
@@ -208,6 +217,7 @@ public final class MySqlConnectionConfiguration {
             tcpKeepAlive == that.tcpKeepAlive &&
             tcpNoDelay == that.tcpNoDelay &&
             Objects.equals(connectTimeout, that.connectTimeout) &&
+            Objects.equals(socketTimeout, that.socketTimeout) &&
             Objects.equals(serverZoneId, that.serverZoneId) &&
             zeroDateOption == that.zeroDateOption &&
             user.equals(that.user) &&
@@ -222,7 +232,7 @@ public final class MySqlConnectionConfiguration {
     @Override
     public int hashCode() {
         return Objects.hash(isHost, domain, port, ssl, tcpKeepAlive, tcpNoDelay,
-            connectTimeout, serverZoneId, zeroDateOption, user, password, database,
+            connectTimeout, socketTimeout, serverZoneId, zeroDateOption, user, password, database,
             preferPrepareStatement, queryCacheSize, prepareCacheSize, extensions);
     }
 
@@ -231,17 +241,19 @@ public final class MySqlConnectionConfiguration {
         if (isHost) {
             return "MySqlConnectionConfiguration{, host='" + domain + "', port=" + port + ", ssl=" + ssl +
                 ", tcpNoDelay=" + tcpNoDelay + ", tcpKeepAlive=" + tcpKeepAlive + ", connectTimeout=" +
-                connectTimeout + ", serverZoneId=" + serverZoneId + ", zeroDateOption=" + zeroDateOption +
-                ", user='" + user + '\'' + ", password=" + password + ", database='" + database +
-                "', preferPrepareStatement=" + preferPrepareStatement + ", queryCacheSize=" + queryCacheSize +
-                ", prepareCacheSize=" + prepareCacheSize + ", extensions=" + extensions + '}';
+                connectTimeout + ", socketTimeout=" + socketTimeout + ", serverZoneId=" + serverZoneId +
+                ", zeroDateOption=" + zeroDateOption + ", user='" + user + '\'' + ", password=" + password +
+                ", database='" + database + "', preferPrepareStatement=" + preferPrepareStatement +
+                ", queryCacheSize=" + queryCacheSize + ", prepareCacheSize=" + prepareCacheSize +
+                ", extensions=" + extensions + '}';
         }
 
         return "MySqlConnectionConfiguration{, unixSocket='" + domain + "', connectTimeout=" +
-            connectTimeout + ", serverZoneId=" + serverZoneId + ", zeroDateOption=" + zeroDateOption +
-            ", user='" + user + "', password=" + password + ", database='" + database +
-            "', preferPrepareStatement=" + preferPrepareStatement + ", queryCacheSize=" + queryCacheSize +
-            ", prepareCacheSize=" + prepareCacheSize + ", extensions=" + extensions + '}';
+            connectTimeout + ", socketTimeout=" + socketTimeout + ", serverZoneId=" + serverZoneId +
+            ", zeroDateOption=" + zeroDateOption + ", user='" + user + "', password=" + password +
+            ", database='" + database + "', preferPrepareStatement=" + preferPrepareStatement +
+            ", queryCacheSize=" + queryCacheSize + ", prepareCacheSize=" + prepareCacheSize +
+            ", extensions=" + extensions + '}';
     }
 
     /**
@@ -263,6 +275,9 @@ public final class MySqlConnectionConfiguration {
 
         @Nullable
         private Duration connectTimeout;
+
+        @Nullable
+        private Duration socketTimeout;
 
         private String user;
 
@@ -331,7 +346,7 @@ public final class MySqlConnectionConfiguration {
             MySqlSslConfiguration ssl = MySqlSslConfiguration.create(sslMode, tlsVersion, sslHostnameVerifier,
                 sslCa, sslKey, sslKeyPassword, sslCert, sslContextBuilderCustomizer);
             return new MySqlConnectionConfiguration(isHost, domain, port, ssl, tcpKeepAlive, tcpNoDelay,
-                connectTimeout, zeroDateOption, serverZoneId, user, password, database,
+                connectTimeout, socketTimeout, zeroDateOption, serverZoneId, user, password, database,
                 preferPrepareStatement, queryCacheSize, prepareCacheSize,
                 Extensions.from(extensions, autodetectExtensions));
         }
@@ -414,6 +429,18 @@ public final class MySqlConnectionConfiguration {
          */
         public Builder connectTimeout(@Nullable Duration connectTimeout) {
             this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        /**
+         * Configure the socket timeout.  Default no timeout.
+         *
+         * @param socketTimeout the socket timeout, or {@code null} if has no timeout.
+         * @return this {@link Builder}.
+         * @since 0.8.3
+         */
+        public Builder socketTimeout(@Nullable Duration socketTimeout) {
+            this.socketTimeout = socketTimeout;
             return this;
         }
 
@@ -755,6 +782,6 @@ public final class MySqlConnectionConfiguration {
             return sslMode;
         }
 
-        private Builder() { }
+        private Builder() {}
     }
 }

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactory.java
@@ -93,7 +93,7 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             int prepareCacheSize = configuration.getPrepareCacheSize();
 
             return Client.connect(ssl, address, configuration.isTcpKeepAlive(), configuration.isTcpNoDelay(),
-                context, configuration.getConnectTimeout())
+                context, configuration.getConnectTimeout(), configuration.getSocketTimeout())
                 .flatMap(client -> QueryFlow.login(client, sslMode, database, user, password, context))
                 .flatMap(client -> {
                     ByteBufAllocator allocator = client.getByteBufAllocator();

--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -138,6 +138,13 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
         SSL_CONTEXT_BUILDER_CUSTOMIZER = Option.valueOf("sslContextBuilderCustomizer");
 
     /**
+     * TCP socket timeout
+     *
+     * @since 0.8.3
+     */
+    public static final Option<Duration> SOCKET_TIMEOUT = Option.valueOf("socketTimeout");
+
+    /**
      * Enable/Disable TCP KeepAlive.
      *
      * @since 0.8.2
@@ -253,6 +260,8 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             .into(builder::autodetectExtensions);
         mapper.from(CONNECT_TIMEOUT).asInstance(Duration.class, Duration::parse)
             .into(builder::connectTimeout);
+        mapper.from(SOCKET_TIMEOUT).asInstance(Duration.class, Duration::parse)
+            .into(builder::socketTimeout);
         mapper.from(DATABASE).asString()
             .into(builder::database);
 

--- a/src/main/java/dev/miku/r2dbc/mysql/client/Client.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/client/Client.java
@@ -112,12 +112,15 @@ public interface Client {
      * @param tcpNoDelay     if enable the {@link ChannelOption#TCP_NODELAY}
      * @param context        the connection context
      * @param connectTimeout connect timeout, or {@code null} if has no timeout
+     * @param socketTimeout  socket timeout, or {@code null} if has no timeout
      * @return A {@link Mono} that will emit a connected {@link Client}.
      * @throws IllegalArgumentException if {@code ssl}, {@code address} or {@code context} is {@code null}.
-     * @throws ArithmeticException      if {@code connectTimeout} milliseconds overflow as an int
+     * @throws ArithmeticException      if {@code connectTimeout} or {@code socketTimeout} milliseconds
+     *                                  overflow as an int
      */
     static Mono<Client> connect(MySqlSslConfiguration ssl, SocketAddress address, boolean tcpKeepAlive,
-        boolean tcpNoDelay, ConnectionContext context, @Nullable Duration connectTimeout) {
+        boolean tcpNoDelay, ConnectionContext context, @Nullable Duration connectTimeout,
+        @Nullable Duration socketTimeout) {
         requireNonNull(ssl, "ssl must not be null");
         requireNonNull(address, "address must not be null");
         requireNonNull(context, "context must not be null");
@@ -127,6 +130,11 @@ public interface Client {
         if (connectTimeout != null) {
             tcpClient = tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
                 Math.toIntExact(connectTimeout.toMillis()));
+        }
+
+        if (socketTimeout != null) {
+            tcpClient = tcpClient.option(ChannelOption.SO_TIMEOUT,
+                Math.toIntExact(socketTimeout.toMillis()));
         }
 
         if (address instanceof InetSocketAddress) {

--- a/src/test/java/dev/miku/r2dbc/mysql/IntegrationTestSupport.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/IntegrationTestSupport.java
@@ -78,6 +78,7 @@ abstract class IntegrationTestSupport {
         MySqlConnectionConfiguration.Builder builder = MySqlConnectionConfiguration.builder()
             .host("127.0.0.1")
             .connectTimeout(Duration.ofSeconds(3))
+            .socketTimeout(Duration.ofSeconds(4))
             .user("root")
             .password(password)
             .database("r2dbc")

--- a/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -195,6 +195,7 @@ class MySqlConnectionConfigurationTest {
             .tcpKeepAlive(true)
             .tcpNoDelay(true)
             .connectTimeout(Duration.ofSeconds(3))
+            .socketTimeout(Duration.ofSeconds(4))
             .sslMode(SslMode.VERIFY_IDENTITY)
             .sslCa(SSL_CA)
             .sslCert("/path/to/mysql/client-cert.pem")

--- a/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
@@ -126,6 +126,7 @@ class MySqlConnectionFactoryProviderTest {
             .option(PASSWORD, "123456")
             .option(SSL, true)
             .option(Option.valueOf(CONNECT_TIMEOUT.name()), Duration.ofSeconds(3).toString())
+            .option(Option.valueOf("socketTimeout"), Duration.ofSeconds(4).toString())
             .option(DATABASE, "r2dbc")
             .option(Option.valueOf("serverZoneId"), "Asia/Tokyo")
             .option(Option.valueOf("useServerPrepareStatement"), AllTruePredicate.class.getName())
@@ -152,6 +153,7 @@ class MySqlConnectionFactoryProviderTest {
         assertThat(configuration.getUser()).isEqualTo("root");
         assertThat(configuration.getPassword()).isEqualTo("123456");
         assertThat(configuration.getConnectTimeout()).isEqualTo(Duration.ofSeconds(3));
+        assertThat(configuration.getSocketTimeout()).isEqualTo(Duration.ofSeconds(4));
         assertThat(configuration.getDatabase()).isEqualTo("r2dbc");
         assertThat(configuration.getZeroDateOption()).isEqualTo(ZeroDateOption.USE_ROUND);
         assertThat(configuration.isTcpKeepAlive()).isTrue();


### PR DESCRIPTION
Like [socket timeout on JDBC](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-connp-props-networking.html#cj-conn-prop_socketTimeout).

See also [socket timeout option on MariaDB](https://github.com/mariadb-corporation/mariadb-connector-r2dbc#:~:text=10s-,socketTimeout,-Sets%20the%20socket).