### PR TITLE
Continuous deployment to Maven Central using GitHub Actions

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -14,5 +14,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Prepare basic configuration
+        run: |
+          mkdir -p ~/.gnupg
+          echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gnupg/secring.gpg.b64
+          base64 -d ~/.gnupg/secring.gpg.b64 > ~/.gnupg/secring.gpg
+
+          mkdir -p ~/.m2
+          echo "<settings><servers><server><id>ossrh</id><username>${{secrets.OSSRH_USERNAME}}</username><password>${{secrets.OSSRH_PASSWORD}}</password></server></servers></settings>" > ~/.m2/settings.xml
       - name: Deploy to release repository
-        run: mvn clean deploy
+        run: mvn clean deploy -Dgpg.passphrase=${{secrets.GPG_PASSPHRASE}}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,18 @@
+name: Maven Release Deploy
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Deploy to release repository
+        run: mvn clean deploy

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -14,5 +14,11 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Prepare basic configuration
+        run: |
+          echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gnupg/secring.gpg.b64
+          base64 -d ~/.gradle/secring.gpg.b64 > ~/.gnupg/secring.gpg
+
+          echo "<settings><servers><server><id>ossrh</id><username>${{secrets.OSSRH_USERNAME}}</username><password>${{secrets.OSSRH_PASSWORD}}</password></server></servers></settings>" > ~/.m2/settings.xml
       - name: Deploy to snapshot repository
-        run: mvn clean deploy
+        run: mvn clean deploy -Dgpg.passphrase=${{secrets.GPG_PASSPHRASE}}

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -1,0 +1,18 @@
+name: Maven Snapshot Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Deploy to snapshot repository
+        run: mvn clean deploy

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -23,4 +23,4 @@ jobs:
           mkdir -p ~/.m2
           echo "<settings><servers><server><id>ossrh</id><username>${{secrets.OSSRH_USERNAME}}</username><password>${{secrets.OSSRH_PASSWORD}}</password></server></servers></settings>" > ~/.m2/settings.xml
       - name: Deploy to snapshot repository
-        run: mvn clean deploy -Dgpg.passphrase=${{secrets.GPG_PASSPHRASE}}
+        run: mvn clean deploy -Dgpg.passphrase=${{secrets.GPG_PASSPHRASE}} -DskipTests

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -16,9 +16,11 @@ jobs:
           java-version: 1.8
       - name: Prepare basic configuration
         run: |
+          mkdir ~/.gnupg
           echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gnupg/secring.gpg.b64
           base64 -d ~/.gnupg/secring.gpg.b64 > ~/.gnupg/secring.gpg
 
+          mkdir ~/.m2
           echo "<settings><servers><server><id>ossrh</id><username>${{secrets.OSSRH_USERNAME}}</username><password>${{secrets.OSSRH_PASSWORD}}</password></server></servers></settings>" > ~/.m2/settings.xml
       - name: Deploy to snapshot repository
         run: mvn clean deploy -Dgpg.passphrase=${{secrets.GPG_PASSPHRASE}}

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Prepare basic configuration
         run: |
           echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gnupg/secring.gpg.b64
-          base64 -d ~/.gradle/secring.gpg.b64 > ~/.gnupg/secring.gpg
+          base64 -d ~/.gnupg/secring.gpg.b64 > ~/.gnupg/secring.gpg
 
           echo "<settings><servers><server><id>ossrh</id><username>${{secrets.OSSRH_USERNAME}}</username><password>${{secrets.OSSRH_PASSWORD}}</password></server></servers></settings>" > ~/.m2/settings.xml
       - name: Deploy to snapshot repository

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -16,11 +16,11 @@ jobs:
           java-version: 1.8
       - name: Prepare basic configuration
         run: |
-          mkdir ~/.gnupg
+          mkdir -p ~/.gnupg
           echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gnupg/secring.gpg.b64
           base64 -d ~/.gnupg/secring.gpg.b64 > ~/.gnupg/secring.gpg
 
-          mkdir ~/.m2
+          mkdir -p ~/.m2
           echo "<settings><servers><server><id>ossrh</id><username>${{secrets.OSSRH_USERNAME}}</username><password>${{secrets.OSSRH_PASSWORD}}</password></server></servers></settings>" > ~/.m2/settings.xml
       - name: Deploy to snapshot repository
         run: mvn clean deploy -Dgpg.passphrase=${{secrets.GPG_PASSPHRASE}}

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,17 @@
                 <version>2.8.2</version>
             </plugin>
             <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.3.0</version>
@@ -362,11 +373,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
@@ -373,11 +373,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
Translated in English:

Continuous deployment to Maven Central using GitHub Actions.
- `deploy-snapshot.yml` will deploy the `main` branch code as SNAPSHOT version to the Sonatype Snapshots repository
- `deploy-release.yml` will deploy tags starting with `v*` as RELEASE version to the Sonatype repository

After merge this PR, project owner need to add OSSRH username, password, GPG Key, etc. in `Settings> Secrets`.
- `SIGNING_SECRET_KEY_RING_FILE` GPG Private Key for jar signature during Maven deployment, and the file should be encoded by Base64.
- `GPG_PASSPHRASE` GPG Private Key passphrase (if it exists)
- `OSSRH_USERNAME` the username for sign in OSSRH
- `OSSRH_PASSWORD` the password of the user for sign in OSSRH

Original version (Chinese):

> 使用 GitHub Actions 自动发布 Maven 版本。
> - `deploy-snapshot.yml`  推送至 main 分布的内容自动发布 SNAPSHOT 版本至 Sonatype 快照仓库中；
> - `deploy-release.yml` 推送的 tags 前缀以 `v*` 开关的标签将自动发布 RELEASE 版本至 Sonatype 仓库中。
>
> 合并代码后，需要在项目的 ` Settings > Secrets` 中增加 OSSRH用户密码、GPG Key 相关配置。
> - `SIGNING_SECRET_KEY_RING_FILE` GPG Private Key 用于 Maven 发布签名的密钥，文件采用 BASE64 编码保存；
> - `GPG_PASSPHRASE` GPG 密钥的密码（如果没有密码可以忽略）；
> - `OSSRH_USERNAME` OSSRH 的登录用户名；
> - `OSSRH_PASSWORD` OSSRH 的登录密码。