### PR TITLE
Set TLSv1.3 as the default version of TLS

### DIFF
--- a/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -433,11 +433,13 @@ public final class MySqlConnectionConfiguration {
         }
 
         /**
-         * Configure the socket timeout.  Default no timeout.
+         * Configure the socket timeout, only for compatibility with {@code socketTimeout} property in the
+         * JDBC driver.  In fact, {@code SO_TIMEOUT} has effect only for OIO socket transport.  Default no
+         * timeout.
          *
          * @param socketTimeout the socket timeout, or {@code null} if has no timeout.
          * @return this {@link Builder}.
-         * @since 0.8.3
+         * @since 0.8.6
          */
         public Builder socketTimeout(@Nullable Duration socketTimeout) {
             this.socketTimeout = socketTimeout;
@@ -782,6 +784,6 @@ public final class MySqlConnectionConfiguration {
             return sslMode;
         }
 
-        private Builder() {}
+        private Builder() { }
     }
 }

--- a/src/main/java/dev/miku/r2dbc/mysql/ServerVersion.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/ServerVersion.java
@@ -24,7 +24,11 @@ import static dev.miku.r2dbc.mysql.util.AssertUtils.requireNonNull;
  */
 public final class ServerVersion implements Comparable<ServerVersion> {
 
-    private static final String[] ENTERPRISES = new String[] { "enterprise", "commercial", "advanced" };
+    private static final String ENTERPRISE = "enterprise";
+
+    private static final String COMMERCIAL = "commercial";
+
+    private static final String ADVANCED = "advanced";
 
     /**
      * Unresolved/origin version pattern, do NOT use it on {@link #hashCode()}, {@link #equals(Object)} or
@@ -95,18 +99,14 @@ public final class ServerVersion implements Comparable<ServerVersion> {
 
     /**
      * Checks if the version is enterprise edition.
+     * <p>
+     * Notice: it is unstable API, should not be used outer than {@literal r2dbc-mysql}.
      *
      * @return if is enterprise edition.
      */
     public boolean isEnterprise() {
-        for (String enterprise : ENTERPRISES) {
-            // Maybe should ignore case?
-            if (origin.contains(enterprise)) {
-                return true;
-            }
-        }
-
-        return false;
+        // Maybe should ignore case?
+        return origin.contains(ENTERPRISE) || origin.contains(COMMERCIAL) || origin.contains(ADVANCED);
     }
 
     @Override

--- a/src/main/java/dev/miku/r2dbc/mysql/constant/TlsVersions.java
+++ b/src/main/java/dev/miku/r2dbc/mysql/constant/TlsVersions.java
@@ -23,28 +23,27 @@ public final class TlsVersions {
 
     /**
      * TLS version 1.0, not recommended. All available MySQL versions support it.
+     * <p>
+     * Notice: it has been disabled in the latest version of JDKs.
      */
     public static final String TLS1 = "TLSv1";
 
     /**
      * TLS version 1.1. All available MySQL versions support it.
+     * <p>
+     * Notice: it has been disabled in the latest version of JDKs.
      */
     public static final String TLS1_1 = "TLSv1.1";
 
     /**
-     * TLS version 1.2. It is supported in 8.0.4 (or higher) Community Edition, or 5.6.0 (or higher)
-     * Enterprise Edition.
-     * <p>
-     * Note: The Enterprise Edition version will looks like {@literal 5.7.26-enterprise}.
+     * TLS version 1.2. Supported in MySQL community edition 8.0, 5.7.28 and later, and 5.6.46 and later, and
+     * for all enterprise editions of MySQL Servers.
      */
     public static final String TLS1_2 = "TLSv1.2";
 
     /**
-     * TLS version 1.3. It is available as of MySQL 8.0.16 or higher, and requires compiling MySQL using
-     * OpenSSL 1.1.1 or higher.
-     * <p>
-     * It will not be used unless user has set it up, because the driver cannot know which compiling library
-     * the MySQL server uses.
+     * TLS version 1.3. Supported in MySQL community edition 8.0, 5.7.28 and later, and 5.6.46 and later, and
+     * for all enterprise editions of MySQL Servers.
      */
     public static final String TLS1_3 = "TLSv1.3";
 

--- a/src/test/java/dev/miku/r2dbc/mysql/IntegrationTestSupport.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/IntegrationTestSupport.java
@@ -78,7 +78,6 @@ abstract class IntegrationTestSupport {
         MySqlConnectionConfiguration.Builder builder = MySqlConnectionConfiguration.builder()
             .host("127.0.0.1")
             .connectTimeout(Duration.ofSeconds(3))
-            .socketTimeout(Duration.ofSeconds(3))
             .user("root")
             .password(password)
             .database("r2dbc")


### PR DESCRIPTION
TLSv1 and TLSv1.2 have been disabled in the latest version of the JDK.
TLSv1.3 has been supported in the MySQL 5.6.46 and 5.7.28.

It resolves #182.