### PR TITLE
fix flaky test in SetCodecTest.java

### DIFF
--- a/src/test/java/dev/miku/r2dbc/mysql/codec/SetCodecTest.java
+++ b/src/test/java/dev/miku/r2dbc/mysql/codec/SetCodecTest.java
@@ -33,7 +33,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -64,10 +64,10 @@ class SetCodecTest implements CodecTestSupport<String[]> {
         Collections.singleton(""),
         Collections.singleton(SomeElement.GOOD),
         Collections.singleton("\r\n\0\032\\'\"\u00a5\u20a9"),
-        new HashSet<>(Arrays.asList("Hello", "world!")),
-        new HashSet<>(Arrays.asList("", "")),
-        new HashSet<>(Arrays.asList(SomeElement.GOOD, SomeElement.NICE)),
-        new HashSet<>(Arrays.asList("Hello", "R2DBC", "MySQL")),
+        new LinkedHashSet<>(Arrays.asList("Hello", "world!")),
+        new LinkedHashSet<>(Arrays.asList("", "")),
+        new LinkedHashSet<>(Arrays.asList(SomeElement.GOOD, SomeElement.NICE)),
+        new LinkedHashSet<>(Arrays.asList("Hello", "R2DBC", "MySQL")),
     };
 
     @Override


### PR DESCRIPTION
As in `sets` it used `HashSet` to store the String array, the order of the String is non-deterministic. I changed it to `LinkedHashSet` so it will convert the array into set while still maintaining the order. This will fix the flaky bug in `binarySet` and `stringifySet`.